### PR TITLE
Update SSCSP markdown link

### DIFF
--- a/supply-chain-security/supply-chain-security-paper/README.md
+++ b/supply-chain-security/supply-chain-security-paper/README.md
@@ -18,7 +18,7 @@ should initiate with an [issue](https://github.com/cncf/tag-security/issues) sub
 
 ### Markdown 
 
-The living SSCSP is maintained in [markdown](https://github.com/cncf/tag-security/blob/master/supply-chain-security/sscsp.md) and all updates will be made in
+The living SSCSP is maintained in [markdown](https://github.com/cncf/tag-security/blob/master/supply-chain-security/supply-chain-security-paper/sscsp.md) and all updates will be made in
  markdown.  
 
 ### Contributing updates 


### PR DESCRIPTION
- Fixes a link to the markdown file in `supply-chain-security-paper/README.md`