### PR TITLE
Add meeting facilitator

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -61,4 +61,4 @@ collaborators:
     permission: push
 
     # Meeting Facilitators
-    # ultrasaurus, dshaw, pragashj, lumjjb, justincormack, izgeri, JustinCappos
+    # ultrasaurus, dshaw, pragashj, lumjjb, justincormack, izgeri, JustinCappos, magnologan


### PR DESCRIPTION
Add @magnologan as a meeting facilitator

- Frequent member of Security TAG meetings since October 2020
- Helped organized the Cloud Native Security Day CTF in 2020 and 2021.
- Server as a facilitator for this meeting once
- Member of the Toastmasters International 