### PR TITLE
SIG => TAG governance/chair-proposal-process

### DIFF
--- a/governance/chair-proposal-process.md
+++ b/governance/chair-proposal-process.md
@@ -1,7 +1,7 @@
-# SIG-Security Chair proposal process
+# Security TAG Chair Proposal Process
 
-1) SIG-Security Co-chairs operate as a team. The Co-Chair team seeks to maintain full coverage of the leadership capabilities across the key qualities of industry experience, hands-on cloud-native and security experience, as well as administrative experience needed to run a SIG-Security.
-2) If a clear successor for the exiting Co-Chair exists based on the merit of their contributions ("chop wood, carry water") and relevant experience that will benefit the SIG, based on the SIG's collective experience over time, the exiting Co-chair may nominate a successor.
-3) The exiting Co-Chair should propose the desired successor to the other Co-Chairs. If there are any objections, the Co-Chair will have the opportunity to propose another worthy candidate. If SIG-Security Chairs, Tech Leads and TOC Liaisons are unable to put forward a candidate, then a selection process will need to be agreed upon and executed.
-4) Upon unanimous consent amongst the current Co-Chairs, the Co-Chairs will ask the TOC Liaisons to propose the candidate for the TOC’s vote in accordance with the [SIG Chair election process](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#elections).
+1) Security TAG Co-chairs operate as a team. The Co-Chair team seeks to maintain full coverage of the leadership capabilities across the key qualities of industry experience, hands-on cloud native and security experience, as well as administrative experience needed to run a [TAG](https://github.com/cncf/toc/tree/main/tags).
+2) If a clear successor for the exiting Co-Chair exists based on the merit of their contributions ("chop wood, carry water") and relevant experience that will benefit the TAG, based on the SIG's collective experience over time, the exiting Co-chair may nominate a successor.
+3) The exiting Co-Chair should propose the desired successor to the other Co-Chairs. If there are any objections, the Co-Chair will have the opportunity to propose another worthy candidate. If Security TAG Chairs, Tech Leads and TOC Liaisons are unable to put forward a candidate, then a selection process will need to be agreed upon and executed.
+4) Upon unanimous consent amongst the current Co-Chairs, the Co-Chairs will ask the TOC Liaisons to propose the candidate for the TOC’s vote in accordance with the TAG Chair election process.
 5) If no new Chair candidate is available, the role will remain vacant until the Co-chair's, TOC Liaisons or CNCF TOC propose a replacement.

--- a/governance/charter.md
+++ b/governance/charter.md
@@ -1,6 +1,6 @@
-# SIG-Security Charter
+# Security TAG Charter
 
-This charter describes operations as a [CNCF SIG](https://github.com/cncf/toc/blob/master/sigs/). The [Focus](#focus) section below describes what is in and out of scope,
+This charter describes operations as a [CNCF TAG](https://github.com/cncf/toc/tree/main/tags). The [Focus](#focus) section below describes what is in and out of scope,
 and [Governance](#governance) section describes how our operations are consistent with CNCF policies with links to more detailed documents.
 
 **Mission:** to reduce risk that cloud native
@@ -45,9 +45,9 @@ requirements
 * Common tooling for audit and reasoning about system properties.
 
 
-### In scope
+### In Scope
 
-Terminology note: SIG-Security uses the term "end user" to describe the humans
+Terminology note: Security TAG uses the term "end user" to describe the humans
 who use cloud native applications, whereas CNCF refers to companies that operate
 cloud native systems as CNCF End Users. In the context of security, we often
 need to discuss how a particular control affects the people who use the software
@@ -59,7 +59,7 @@ system or the privacy of its users,  specifically how to enable secure
 access, policy control and safety for operators, administrators,
 developers, and end-users  across the cloud native ecosystem.
 
-SIG-Security will consider [proposals](process.md) from its members or delegated
+Security TAG will consider [proposals](process.md) from its members or delegated
 tasks from the CNCF TOC that are consistent with the mission, including
 the following activities:
 
@@ -79,14 +79,14 @@ the following activities:
   * Best practices and anti-patterns (potentially highlighting where there is disagreement on these)
 * Security assessments of specific proposals or projects
 * Identify projects for consideration for CNCF
-* Cross-pollinate knowledge by participating and inviting people from other projects and SIGs to share security practices
-* Integrate relevant external standards, such as from CII or NIST, as part of educational resources and/or SIG processes
+* Cross-pollinate knowledge by participating and inviting people from other projects and TAGs to share security practices
+* Integrate relevant external standards, such as from CII or NIST, as part of educational resources and/or TAG processes
 
 Given that the group is comprised of volunteers, specific requests from the TOC
 may be queued according to the bandwidth of the group. The co-chairs will
-facilitate prioritization under the guidance of the SIG-Security TOC liaison.
+facilitate prioritization under the guidance of the Security TAG TOC liaison.
 
-### Out of scope
+### Out of Scope
 * Not a standards body: We won't be creating standards.
 * Not an umbrella organization: We interact with other groups for knowledge
   sharing, not decision-making.
@@ -109,21 +109,21 @@ Security must be addressed at all levels of the stack and across the whole
 ecosystem, so the group seeks to encourage participation and membership across
 a wide range of roles, from diverse companies and organizations.
 
-### Cross-group relationships
+### Cross-group Relationships
 To focus our efforts, we avoid duplication by developing relationships with
 other groups that
 focus on a particular technology (such as Kubernetes SIGs) or have a broader
 mandate (such as government organizations).
 
-As a guide to visitors, we maintain the list of groups in the SIG
-[README](https://github.com/cncf/sig-security#related-groups).
+As a guide to visitors, we maintain the list of groups in the TAG
+[README](https://github.com/cncf/tag-security#related-groups).
 
 Co-chairs are responsible to ensure periodic cross-group knowledge sharing,
 which is accomplished by cross-group membership, invitation to present at
-a SIG meeting and/or offering to present to the related group.
+a TAG meeting and/or offering to present to the related group.
 
 ## Operations
-SIG-Security operations are consistent with standard SIG operating guidelines
+Security TAG operations are consistent with standard TAG guidelines
 provided by the CNCF Technical Oversight Committee
 [TOC](https://github.com/cncf/toc).
 

--- a/governance/github.md
+++ b/governance/github.md
@@ -15,8 +15,8 @@ control access privileges, not in the Github UI (so they are visible to
 everyone.)  
 
 Note: Members of the CNCF TOC and some CNCF staff also have admin access;
-however, SIG Roles will be defined transparently using files described below,
-and will follow SIG processes in making any changes. 
+however, TAG Roles will be defined transparently using files described below,
+and will follow TAG processes in making any changes. 
 
 ## Settings file  
 Pull Requests to appoint members to new Roles in

--- a/governance/presentations.md
+++ b/governance/presentations.md
@@ -1,4 +1,4 @@
-# Security TAG presentations
+# Security TAG Presentations
 
 Part of the STAG activities include having guest presentations by members of the community. 
 We welcome any topic related to our mission and charter. Typical topics include projects, 
@@ -7,9 +7,9 @@ following guidelines.
 
 ## Guidelines
 
-- Presentations are encouraged to expose the SIG to cloud native open source projects, cloud native security concepts, and other cloud native or security groups.
+- Presentations are encouraged to expose the TAG to cloud native open source projects, cloud native security concepts, and other cloud native or security groups.
 - Presentations should fit with [our charter](https://github.com/cncf/tag-security/blob/master/governance/charter.md)
-- Presentations should not be scheduled on the Agenda until the issue is filled in and the SIG representative has performed due diligence on the issue
+- Presentations should not be scheduled on the Agenda until the issue is filled in and the TAG representative has performed due diligence on the issue
 - Presentations should abide by the CNCF code of conduct
 
 Examples of topics that are within scope:

--- a/governance/roles.md
+++ b/governance/roles.md
@@ -1,6 +1,6 @@
-# Roles within the SIG
+# Roles within the TAG
 
-The SIG includes several key roles that are critical to the group's success.
+The TAG includes several key roles that are critical to the group's success.
 The group will have many members, all serving in varying capacities.  Within
 this document, "member" may refer to a Chair, a Technical Lead, or other
 Member roles.
@@ -14,10 +14,10 @@ The following is the current listing of member roles:
 * [TOC Liaison](#toc-liaison)
 * [Facilitation Roles](#facilitation-roles)
 
-All members are identified in the SIG [README](/readme.md), with annotations
+All members are identified in the TAG [README](/readme.md), with annotations
 where they hold an additional role. 
 
-Members fulfilling any Roles in SIG-Security are responsible for understanding
+Members fulfilling any Roles in Security TAG are responsible for understanding
 and abiding the by the [governance](./) and policies defined in this group.
 This commitment and execution of understanding includes not only commits to
 the repo, but also to any approvals or direction required by their Role.
@@ -50,15 +50,15 @@ removal may occur through a super-majority vote of the Chairs.
 
 ### Managing membership
 * Membership disagreements may be escalated to the Chairs.  Disagreements
-among the Chairs may be escalated to a SIG-Security TOC Liaison.
+among the Chairs may be escalated to a Security TAG TOC Liaison.
 * Members *MAY* decide to step down at anytime and optionally propose a
 replacement.
 
 ## Role of chairs
 
 While CNCF TOC allows for Chairs to serve in purely administrative roles,
-SIG-Security was formed with deeply technical Chairs based on early need
-to navigate a complex security landscape. If the SIG has less than two Technical
+Security TAG was formed with deeply technical Chairs based on early need
+to navigate a complex security landscape. If the TAG has less than two Technical
 Leads, any Chair may act as Technical Lead.
 
 * Primary role of Chairs is to run operations and the governance of the group.
@@ -78,7 +78,7 @@ members who cannot attend a specific meeting time.
 
 Technical Leads (TLs) expand the bandwidth of the leadership team. Proposals
 must have a TL or Chair working as an active sponsor (as detailed in 
-[SIG process](process.md)).
+[TAG process](process.md)).
 
 The general list of activities for TL are:
   * Establish new subprojects
@@ -87,8 +87,7 @@ The general list of activities for TL are:
   * Propose agenda items for meetings to ensure that open issues are
   discussed with the group when needed
 
-TLs are assigned by CNCF Technical Oversight Committee
-(see [CNCF SIG Tech Lead nomination and election process](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#elections)).
+TLs are assigned by CNCF Technical Oversight Committee.
 
 ## Role of project leads
 
@@ -100,7 +99,7 @@ Project Leads are nominated and approved by the following process:
   volunteering to take on a project that has been prioritized by the group
   1. A Chair or TL nominates a candidate.
   1. The nomination is communicated via a pull request annotating the list of members in the 
-  [SIG README](/README.md) with a link to the issue tracking the project. 
+  [TAG README](/README.md) with a link to the issue tracking the project. 
   The nomination is typically open for a week (but may be shorter with LGTM of at least two Chairs).
   1. Members are encouraged to review the tracking issue and work together
   to ensure that the Project Lead is set up for success or suggest alternatives.
@@ -111,12 +110,12 @@ project.
 
 ## TOC liaison
 
-The [CNCF SIG](https://github.com/cncf/toc/blob/master/sigs) process identifies
-a TOC Liaison.  The SIG Chairs are responsible for establishing effective
+The [CNCF TAG](https://github.com/cncf/toc/tree/main/tags) process identifies
+a TOC Liaison.  The TAG Chairs are responsible for establishing effective
 communication with the TOC liaison, including further communication to the
 wider TOC upon request.
 
-The TOC Liaison will occasionally prioritize SIG activities, as needed by the
+The TOC Liaison will occasionally prioritize TAG activities, as needed by the
 TOC, to further the [CNCF mission](https://github.com/cncf/foundation/blob/master/charter.md#1-mission-of-the-cloud-native-computing-foundation).
 
 


### PR DESCRIPTION
* SIG => TAG
* I am not finding an equivalent link to replace for https://github.com/cncf/toc/blob/main/sigs/cncf-sigs.md#elections.  Removed as better missing than dead.
* cloud-native => cloud native