### PR TITLE
wrap at 80 columns, trim trailing whitespace

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,31 +1,39 @@
-# Code of Conduct 
+# Code of Conduct
 
-We follow the 
-[CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) 
+We follow the [CNCF Code of
+Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
 
 As part of our pledge to respect all people, in both live in-person and online
 interactions, we are committed to providing a friendly, safe and welcoming
 environment for all, regardless of gender, gender identity and expression,
 sexual orientation, disability, physical appearance, body size, race, religion,
 native language, operating system choice, current software stack or prior
-experience. 
+experience.
 
 In keeping with this commitment, we offer the following guidelines:
-   * Welcome newcomers at any stage of expertise. 
-     * Everyone has something to contribute. 
-     * Everyone deserves access to materials and community that will help them learn. 
-     * As long as an individual can be respectful and not disruptive to other participants, they deserve to participate.
+   * Welcome newcomers at any stage of expertise.
+     * Everyone has something to contribute.
+     * Everyone deserves access to materials and community that will help them
+       learn.
+     * As long as an individual can be respectful and not disruptive to other
+       participants, they deserve to participate.
    * Provide open and free material.
    * Be kind and courteous.
      * Interpret the arguments of others in good faith, offering private
-     constructive feedback when communication style bears improvement.
+       constructive feedback when communication style bears improvement.
      * Leave space for quieter voices.
-   * Consider who is not in the room. 
+   * Consider who is not in the room.
      * Invite participation from experts or user community representatives
-     outside of the working group.
-     * Participate in online forums to be inclusive of those who cannot 
-     attend meetings.
-   * Work performed within this group, either finalized or in draft, is to be used in accordance with the group [Mission and Charter](https://github.com/cncf/tag-security/blob/main/governance/charter.md), the open source license, and to be used for the equal benefit of all members of the community.  Further information on use of work may be found in [Security Assessments: Outcome](https://github.com/cncf/tag-security/tree/main/assessments#outcome)
+       outside of the working group.
+     * Participate in online forums to be inclusive of those who cannot attend
+       meetings.
+   * Work performed within this group, either finalized or in draft, is to be
+     used in accordance with the group [Mission and
+     Charter](https://github.com/cncf/tag-security/blob/main/governance/charter.md),
+     the open source license, and to be used for the equal benefit of all
+     members of the community.  Further information on use of work may be found
+     in [Security Assessments:
+     Outcome](https://github.com/cncf/tag-security/tree/main/assessments#outcome)
 
 # Inspiration
 


### PR DESCRIPTION
reviewing diffs is easier if text is wrapped at 80 columns 

if this looks good, then ideally it would be merged before https://github.com/cncf/tag-security/pull/652