### PR TITLE
Add chasemp (Chase Pettet) to meeting facilitators

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -61,4 +61,4 @@ collaborators:
     permission: push
 
     # Meeting Facilitators
-    # ultrasaurus, dshaw, pragashj, lumjjb, justincormack, izgeri, JustinCappos, magnologan, TheFoxAtWork, anvega, achetal01, ashutosh-narkar
+    # ultrasaurus, dshaw, pragashj, lumjjb, justincormack, izgeri, JustinCappos, magnologan, TheFoxAtWork, anvega, achetal01, ashutosh-narkar, chasemp


### PR DESCRIPTION
This is an informational non-impacting update of meeting facilitators.