### PR TITLE
fix(ci): resolve issue with relative URL link check erroring

### DIFF
--- a/ci/link-check-config.json
+++ b/ci/link-check-config.json
@@ -2,5 +2,11 @@
     "timeout": "20s",
     "retryOn429": true,
     "retryCount": 3,
-    "fallbackRetryDelay": "5s"    
+    "fallbackRetryDelay": "5s",
+    "replacementPatterns": [
+        {
+          "pattern": "^(?!https:)(/.*.md)",
+          "replacement": "https://github.com/cncf/tag-security/blob/main$1"
+        }
+    ]    
 }

--- a/ci/link-check-config.json
+++ b/ci/link-check-config.json
@@ -4,9 +4,9 @@
     "retryCount": 3,
     "fallbackRetryDelay": "5s",
     "replacementPatterns": [
-        {
-          "pattern": "^(?!https:)(/.*.md)",
-          "replacement": "https://github.com/cncf/tag-security/blob/main$1"
-        }
+      {
+        "pattern": "^/",
+        "replacement": "{{BASEURL}}/"
+      }
     ]    
 }


### PR DESCRIPTION
Fixes an error when relative URL link check fails like in #701 

This config will replace relative URLs with absolute ones based off of main to better check the validity of the links