### PR TITLE
Improve the regexp for handling .md files

### DIFF
--- a/ci/spelling.sh
+++ b/ci/spelling.sh
@@ -2,4 +2,4 @@
 
 npm install -g cspell
 git fetch origin main:main
-git diff --name-only main $HEAD | grep .md | xargs --no-run-if-empty -L1 npx cspell -c ./ci/spelling-config.json
+git diff --name-only main $HEAD | grep '\.md$' | xargs --no-run-if-empty -L1 npx cspell -c ./ci/spelling-config.json


### PR DESCRIPTION
Example of how it worked before and works now:
```shell
$ echo -e "test1.md\ntest2.xmd\ntest3.md.gz" | grep .md
test1.md
test2.xmd
test3.md.gz
$ echo -e "test1.md\ntest2.xmd\ntest3.md.gz" | grep '\.md$'
test1.md
```

See for details: https://github.com/cncf/tag-security/pull/706#discussion_r660478220