### PR TITLE
add new words to the spelling config

### DIFF
--- a/ci/spelling-config.json
+++ b/ci/spelling-config.json
@@ -26,6 +26,8 @@
         "Cappos",
         "ericavonb",
         "HIPAA",
-        "CODEOWNERS"
+        "CODEOWNERS",
+        "opps",
+        "usecase"
     ]
 }


### PR DESCRIPTION
@ultrasaurus this should address those issues you were seeing. Cspell splits camel case words and checks them against the dictionary so its not seeing opps and usecases in it then flagging them. This file extends the dictionary for cases like this. The entries are case insensitive so "opps" should cover "Opps".

Frees up #75