### PR TITLE
fix spellcheck error in 609-proposal-project branch

### DIFF
--- a/ci/spelling-config.json
+++ b/ci/spelling-config.json
@@ -2,9 +2,9 @@
     "version": "0.1",
     "language": "en",
     "ignorePaths": [
-        "**/.github/**",
+        "**/.github/workflows/**",
         "**/ci/**"
-    ],    
+    ],
     "words": [
         "CNCF",
         "OWASP",


### PR DESCRIPTION
via @JohnHillegass 
> So I think where this is messing up is we excluded that whole .github dir from cspell execution but grep is seeing markdown files changed there and passing forward to xargs. Since the first arg is not empty xargs is taking it and passing to cspell. Cspell since its been told to skip that path, returns a non-zero code and xargs throws the 123. Changing like above handles this case. To fix we will need to change ignorePaths "**/.github/**" to "**/.github/workflows/**" in the ci/spelling-config.json

