### PR TITLE
README: Update timezone links to more helpful ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ and posting to the channels.
 
 Group meeting times are listed below:
 
-- US:   Weekly on Wednesdays at 10:00am GMT-7 (see your timezone
-  [here](https://time.is/compare/1000_27_Jan_2021_in_PT))
-- APAC: Bi-weekly on Tuesdays at 1:00pm GMT+11 (see your timezone
-  [here](https://time.is/compare/1300_26_Jan_2021_in_AEDT))
+- US:   Weekly on Wednesdays at 10:00am UTC-7 (see your timezone
+  [here](https://time.is/1000_today_in_PT?CNCF_Security_TAG_Meeting))
+- APAC: Bi-weekly on Tuesdays at 1:00pm UTC+11 (see your timezone
+  [here](https://time.is/1300_today_in_AEDT?CNCF_Security_TAG_Meeting))
 
 See the  [CNCF Calendar](https://www.cncf.io/calendar/) for calendar invites.
 


### PR DESCRIPTION
- Use "today" as a date, rather than a given date (should keep working even after DST changes)
- Show conversion only for the time we our interested in (the meeting) rather than every hour of the day
Note : for the APAC meeting, AEDT (Australia Eastern Daylight Time) is not currently observed, as East Australia is currently on AEST. Not sure what the best option is here, maybe clarify if we settle on Sydney time, for instance?

Also, change GMT to UTC, which is technically more correct (for what that matters…)