### PR TITLE
Add SLSA Maintainers to related groups

### DIFF
--- a/governance/related-groups/README.md
+++ b/governance/related-groups/README.md
@@ -60,6 +60,9 @@ the work of Security TAG
 * [NIST Computer Security Resource Center](https://csrc.nist.gov/)
   * Security TAG members:
 
+* [OpenSSF SLSA Maintainers](https://slsa.dev/)
+  * Security TAG members: @mlieberman85
+
 ## Don't see a group mentioned or notice a group that needs an update ?
 
 Please consider adding or updating the group using the following


### PR DESCRIPTION
The above name of the group might change as the groups just
started and things like name, governance, etc. might change over
time. Will update if/when it does.