### PR TITLE
Fix link in contribution guide

### DIFF
--- a/CONTRIBUTING/first-time-contributions.md
+++ b/CONTRIBUTING/first-time-contributions.md
@@ -60,4 +60,4 @@ Our members list can be found
 
 Once you have successfully get your
 first PR merged, you can add your name
-to our Members section in [README.md](https://github.com/cncf/tag-security/blob/main/README.md).
+to our Members section in [README.md](https://github.com/cncf/tag-security#members).

--- a/CONTRIBUTING/first-time-contributions.md
+++ b/CONTRIBUTING/first-time-contributions.md
@@ -60,4 +60,4 @@ Our members list can be found
 
 Once you have successfully get your
 first PR merged, you can add your name
-to our Members section in [README.md](README.md).
+to our Members section in [README.md](https://github.com/cncf/tag-security/blob/main/README.md).


### PR DESCRIPTION
I think the "Members section in `README.md`", which means the `README.md` file in the root.