### PR TITLE
Add klow / klown / okhsa, ua-parser-js, coa, rc breaches

### DIFF
--- a/supply-chain-security/compromises/2021/coa-rc.md
+++ b/supply-chain-security/compromises/2021/coa-rc.md
@@ -1,0 +1,19 @@
+# Compromise of NPM packages coa and rc
+
+In early November 2021, the developer accounts of popular NPM packages coa (over 8 million weekly downloads) and rc (over 14 million weekly downloads) were hijacked, allowing attackers to publish malicious versions that downloaded and installed a version of the Qakbot trojan.
+
+This attack is similar to the [ua-parser-js attack](ua-parser-js.md).
+
+## Impact
+
+The coa breach was spotted after build pipelines began crashing, prompting an investigation from NPM. The rc breach was discovered later the same day. Due to the extent of use of both libraries and the fact that the malicious code caused pipelines to fail in some environments, the breaches were spotted quite early (the GitHub thread for coa indicates it was opened 10 minutes after the release). A more sophosticated, "silent" attack along the same vector could have resulted in far more damage.
+
+## Type of Compromise
+
+These attacks was carried out by someone posing as the respective maintainers, and therefore can be classified as "Malicious Maintainer".
+
+## References
+
+- [GitHub thread about the coa breach](https://github.com/veged/coa/issues/99)
+- [GitHub thread about the rc breach](https://github.com/dominictarr/rc/issues/131)
+- [Sonatype article about coa and rc](https://blog.sonatype.com/npm-hijackers-at-it-again-popular-coa-and-rc-open-source-libraries-taken-over-to-spread-malware)

--- a/supply-chain-security/compromises/2021/coa-rc.md
+++ b/supply-chain-security/compromises/2021/coa-rc.md
@@ -1,17 +1,27 @@
 <!-- cSpell:ignore Qakbot Sonatype -->
 # Compromise of NPM packages coa and rc
 
-In early November 2021, the developer accounts of popular NPM packages coa (over 8 million weekly downloads) and rc (over 14 million weekly downloads) were hijacked, allowing attackers to publish malicious versions that downloaded and installed a version of the Qakbot trojan.
+In early November 2021, the developer accounts of popular NPM packages coa (over
+8 million weekly downloads) and rc (over 14 million weekly downloads) were
+hijacked, allowing attackers to publish malicious versions that downloaded and
+installed a version of the Qakbot trojan.
 
 This attack is similar to the [ua-parser-js attack](ua-parser-js.md).
 
 ## Impact
 
-The coa breach was spotted after build pipelines began crashing, prompting an investigation from NPM. The rc breach was discovered later the same day. Due to the extent of use of both libraries and the fact that the malicious code caused pipelines to fail in some environments, the breaches were spotted quite early (the GitHub thread for coa indicates it was opened 10 minutes after the release). A more sophisticated, "silent" attack along the same vector could have resulted in far more damage.
+The coa breach was spotted after build pipelines began crashing, prompting an
+investigation from NPM. The rc breach was discovered later the same day. Due to
+the extent of use of both libraries and the fact that the malicious code caused
+pipelines to fail in some environments, the breaches were spotted quite early
+(the GitHub thread for coa indicates it was opened 10 minutes after the
+release). A more sophisticated, "silent" attack along the same vector could have
+resulted in far more damage.
 
 ## Type of Compromise
 
-These attacks was carried out by someone posing as the respective maintainers, and therefore can be classified as "Malicious Maintainer".
+These attacks was carried out by someone posing as the respective maintainers,
+and therefore can be classified as "Malicious Maintainer".
 
 ## References
 

--- a/supply-chain-security/compromises/2021/coa-rc.md
+++ b/supply-chain-security/compromises/2021/coa-rc.md
@@ -1,3 +1,4 @@
+<!-- cSpell:ignore Qakbot Sonatype -->
 # Compromise of NPM packages coa and rc
 
 In early November 2021, the developer accounts of popular NPM packages coa (over 8 million weekly downloads) and rc (over 14 million weekly downloads) were hijacked, allowing attackers to publish malicious versions that downloaded and installed a version of the Qakbot trojan.
@@ -6,7 +7,7 @@ This attack is similar to the [ua-parser-js attack](ua-parser-js.md).
 
 ## Impact
 
-The coa breach was spotted after build pipelines began crashing, prompting an investigation from NPM. The rc breach was discovered later the same day. Due to the extent of use of both libraries and the fact that the malicious code caused pipelines to fail in some environments, the breaches were spotted quite early (the GitHub thread for coa indicates it was opened 10 minutes after the release). A more sophosticated, "silent" attack along the same vector could have resulted in far more damage.
+The coa breach was spotted after build pipelines began crashing, prompting an investigation from NPM. The rc breach was discovered later the same day. Due to the extent of use of both libraries and the fact that the malicious code caused pipelines to fail in some environments, the breaches were spotted quite early (the GitHub thread for coa indicates it was opened 10 minutes after the release). A more sophisticated, "silent" attack along the same vector could have resulted in far more damage.
 
 ## Type of Compromise
 

--- a/supply-chain-security/compromises/2021/klow-klown-okhsa.md
+++ b/supply-chain-security/compromises/2021/klow-klown-okhsa.md
@@ -1,3 +1,4 @@
+<!-- cSpell:ignore klow klown Sonatype okhsa cryptominert -->
 # The klow / klown / okhsa incident
 
 On October 20, 2021, Sonatype reported that their automated malware detection systems detected multiple malicious packages on NPM. They were klow, klown, and okhsa which introduced a dependency on klown. THe incident was reported to NPM on October 15, and the packages were taken down the same day.

--- a/supply-chain-security/compromises/2021/klow-klown-okhsa.md
+++ b/supply-chain-security/compromises/2021/klow-klown-okhsa.md
@@ -1,0 +1,17 @@
+# The klow / klown / okhsa incident
+
+On October 20, 2021, Sonatype reported that their automated malware detection systems detected multiple malicious packages on NPM. They were klow, klown, and okhsa which introduced a dependency on klown. THe incident was reported to NPM on October 15, and the packages were taken down the same day.
+
+## Impact
+
+Sonatype discovered that klown was published to NPM a few hours after klow was taken down by the administrators, and that klown pretended to be another legitimate package, ua-parser-js. The malicious packages downloaded an executable cryptominer binary during the pre-install phase, and executed it. Luckily, the packages weren't downloaded a significant number of times.
+
+Interestingly, a few days after this incident, the ua-parser-js package was hijacked, and malicious versions with similar cryptomining functions were released on NPM. This incident is written up in greater detail [here](ua-parser-js.md).
+
+## Type of Compromise
+
+Unclear, as these seem to have been new packages that were relatively unused. However, this incident is relevant because of its connection to the ua-parser-js incident.
+
+## References
+
+- [Sonatype article about klow / klown / okhsa](https://blog.sonatype.com/newly-found-npm-malware-mines-cryptocurrency-on-windows-linux-macos-devices)

--- a/supply-chain-security/compromises/2021/klow-klown-okhsa.md
+++ b/supply-chain-security/compromises/2021/klow-klown-okhsa.md
@@ -1,17 +1,30 @@
 <!-- cSpell:ignore klow klown Sonatype okhsa cryptominer -->
 # The klow / klown / okhsa incident
 
-On October 20, 2021, Sonatype reported that their automated malware detection systems detected multiple malicious packages on NPM. They were klow, klown, and okhsa which introduced a dependency on klown. THe incident was reported to NPM on October 15, and the packages were taken down the same day.
+On October 20, 2021, Sonatype reported that their automated malware detection
+systems detected multiple malicious packages on NPM. They were klow, klown, and
+okhsa which introduced a dependency on klown. The incident was reported to NPM
+on October 15, and the packages were taken down the same day.
 
 ## Impact
 
-Sonatype discovered that klown was published to NPM a few hours after klow was taken down by the administrators, and that klown pretended to be another legitimate package, ua-parser-js. The malicious packages downloaded an executable cryptominer binary during the pre-install phase, and executed it. Luckily, the packages weren't downloaded a significant number of times.
+Sonatype discovered that klown was published to NPM a few hours after klow was
+taken down by the administrators, and that klown pretended to be another
+legitimate package, ua-parser-js. The malicious packages downloaded an
+executable cryptominer binary during the pre-install phase, and executed it.
+Luckily, the packages weren't downloaded a significant number of times.
 
-Interestingly, a few days after this incident, the ua-parser-js package was hijacked, and malicious versions with similar cryptomining functions were released on NPM. This incident is written up in greater detail [here](ua-parser-js.md).
+Interestingly, a few days after this incident, the ua-parser-js package was
+hijacked, and malicious versions with similar cryptomining functions were
+released on NPM. This incident is written up in greater detail
+[here](ua-parser-js.md).
 
 ## Type of Compromise
 
-Unclear, as these seem to have been new packages that were relatively unused. However, this incident is relevant because of its connection to the ua-parser-js incident.
+As these seem to have been new packages that were relatively unused, this can be
+categorized as Negligence since the packages pretended to be another legitimate
+package. However, this incident is relevant because of its connection to the
+ua-parser-js incident.
 
 ## References
 

--- a/supply-chain-security/compromises/2021/klow-klown-okhsa.md
+++ b/supply-chain-security/compromises/2021/klow-klown-okhsa.md
@@ -1,4 +1,4 @@
-<!-- cSpell:ignore klow klown Sonatype okhsa cryptominert -->
+<!-- cSpell:ignore klow klown Sonatype okhsa cryptominer -->
 # The klow / klown / okhsa incident
 
 On October 20, 2021, Sonatype reported that their automated malware detection systems detected multiple malicious packages on NPM. They were klow, klown, and okhsa which introduced a dependency on klown. THe incident was reported to NPM on October 15, and the packages were taken down the same day.

--- a/supply-chain-security/compromises/2021/ua-parser-js.md
+++ b/supply-chain-security/compromises/2021/ua-parser-js.md
@@ -1,3 +1,4 @@
+<!-- cSpell:ignore klow klown Sonatype okhsa cryptominer -->
 # Compromise of NPM package ua-parser-js
 
 On October 22, 2021, the developer of popular NPM package ua-parser-js (over 7 million weekly downloads) reported that their account was hijacked, allowing attackers to publish malicious versions that included malware. The developer noticed because of a flurry of spam emails that (they suspect) were sent to mask the NPM emails, and quickly deprecated the malicious versions and put out a notice that stated their NPM account was hijacked.

--- a/supply-chain-security/compromises/2021/ua-parser-js.md
+++ b/supply-chain-security/compromises/2021/ua-parser-js.md
@@ -1,6 +1,6 @@
 # Compromise of NPM package ua-parser-js
 
-On October 22, 2021, the developer of popular NPM package ua-parser-js (over 7 million weekly downloads) reported that their account was hijacked, allowing attackers to publish malicious versions that included a cryptominer. The developer noticed because of a flurry of spam emails that (they suspect) were sent to mask the NPM emails, and quickly deprecated the malicious versions and put out a notice that stated their NPM account was hijacked.
+On October 22, 2021, the developer of popular NPM package ua-parser-js (over 7 million weekly downloads) reported that their account was hijacked, allowing attackers to publish malicious versions that included malware. The developer noticed because of a flurry of spam emails that (they suspect) were sent to mask the NPM emails, and quickly deprecated the malicious versions and put out a notice that stated their NPM account was hijacked.
 
 This attack seems to be related to the [klow /klown /okhsa attack](klow-klown-okhsa.md).
 

--- a/supply-chain-security/compromises/2021/ua-parser-js.md
+++ b/supply-chain-security/compromises/2021/ua-parser-js.md
@@ -1,17 +1,28 @@
 <!-- cSpell:ignore klow klown Sonatype okhsa cryptominer -->
 # Compromise of NPM package ua-parser-js
 
-On October 22, 2021, the developer of popular NPM package ua-parser-js (over 7 million weekly downloads) reported that their account was hijacked, allowing attackers to publish malicious versions that included malware. The developer noticed because of a flurry of spam emails that (they suspect) were sent to mask the NPM emails, and quickly deprecated the malicious versions and put out a notice that stated their NPM account was hijacked.
+On October 22, 2021, the developer of popular NPM package ua-parser-js (over 7
+million weekly downloads) reported that their account was hijacked, allowing
+attackers to publish malicious versions that included malware. The developer
+noticed because of a flurry of spam emails that (they suspect) were sent to mask
+the NPM emails, and quickly deprecated the malicious versions and put out a
+notice that stated their NPM account was hijacked.
 
-This attack seems to be related to the [klow /klown /okhsa attack](klow-klown-okhsa.md).
+This attack seems to be related to the [klow /klown /okhsa
+attack](klow-klown-okhsa.md).
 
 ## Impact
 
-The attacker released versions 0.7.29, 0.8.0, and 1.0.0 going by the release history and deprecated notices on the NPM page. Likely, this was done to attack as many people as possible, based on the versioning rules they used in their manifests. The malicious versions downloaded an externally hosted binary that was then executed with arguments specifying the mining pools to use.
+The attacker released versions 0.7.29, 0.8.0, and 1.0.0 going by the release
+history and deprecated notices on the NPM page. Likely, this was done to attack
+as many people as possible, based on the versioning rules they used in their
+manifests. The malicious versions downloaded an externally hosted binary that
+was then executed with arguments specifying the mining pools to use.
 
 ## Type of Compromise
 
-This attack was carried out by someone posing as the maintainer, and therefore can be classified as "Malicious Maintainer".
+This attack was carried out by someone posing as the maintainer, and therefore
+can be classified as "Malicious Maintainer".
 
 ## References
 

--- a/supply-chain-security/compromises/2021/ua-parser-js.md
+++ b/supply-chain-security/compromises/2021/ua-parser-js.md
@@ -1,0 +1,19 @@
+# Compromise of NPM package ua-parser-js
+
+On October 22, 2021, the developer of popular NPM package ua-parser-js (over 7 million weekly downloads) reported that their account was hijacked, allowing attackers to publish malicious versions that included a cryptominer. The developer noticed because of a flurry of spam emails that (they suspect) were sent to mask the NPM emails, and quickly deprecated the malicious versions and put out a notice that stated their NPM account was hijacked.
+
+This attack seems to be related to the [klow /klown /okhsa attack](klow-klown-okhsa.md).
+
+## Impact
+
+The attacker released versions 0.7.29, 0.8.0, and 1.0.0 going by the release history and deprecated notices on the NPM page. Likely, this was done to attack as many people as possible, based on the versioning rules they used in their manifests. The malicious versions downloaded an externally hosted binary that was then executed with arguments specifying the mining pools to use.
+
+## Type of Compromise
+
+This attack was carried out by someone posing as the maintainer, and therefore can be classified as "Malicious Maintainer".
+
+## References
+
+- [GitHub thread about the incident](https://github.com/faisalman/ua-parser-js/issues/536)
+- [Diff between clean and malicious versions](https://app.renovatebot.com/package-diff?name=ua-parser-js&from=0.7.28&to=1.0.0)
+- [Sonatype article about klow / klown / okhsa](https://blog.sonatype.com/newly-found-npm-malware-mines-cryptocurrency-on-windows-linux-macos-devices)

--- a/supply-chain-security/compromises/README.md
+++ b/supply-chain-security/compromises/README.md
@@ -32,7 +32,7 @@ of compromise needs added, please include that as well.
 | ----------------- | ------------------ | ------------------    | ----------- |
 | [Compromise of NP packages coa and rc](2021/coa-rc.md) | 2021 | Malicious Maintainer | [1](https://blog.sonatype.com/npm-hijackers-at-it-again-popular-coa-and-rc-open-source-libraries-taken-over-to-spread-malware) |
 | [Compromise of ua-parser-js](2021/ua-parser-js.md) | 2021 | Malicious Maintainer | [1](https://github.com/faisalman/ua-parser-js/issues/536) |
-| [The klow / klown / okhsa incident](2021/klow-klown-okhsa.md) | 2021 |  | [1](https://blog.sonatype.com/newly-found-npm-malware-mines-cryptocurrency-on-windows-linux-macos-devices) |
+| [The klow / klown / okhsa incident](2021/klow-klown-okhsa.md) | 2021 | Negligence | [1](https://blog.sonatype.com/newly-found-npm-malware-mines-cryptocurrency-on-windows-linux-macos-devices) |
 | [PHP self-hosted git server](2021/php.md) | 2021 | Dev Tooling | [1](https://news-web.php.net/php.internals/113838) |
 | [Homebrew](2021/homebrew.md) | 2021 | Dev Tooling | [1](https://brew.sh/2021/04/21/security-incident-disclosure/), [2](https://hackerone.com/reports/1167608) |  |
 | [Codecov](2021/codecov.md) | 2021 | Source Code | [1](https://about.codecov.io/security-update/) |  |

--- a/supply-chain-security/compromises/README.md
+++ b/supply-chain-security/compromises/README.md
@@ -66,7 +66,7 @@ of compromise needs added, please include that as well.
 | [Bitcoin Gold](2017/bitcoingold.md) | 2017 | Source Code | [1](https://bitcoingold.org/critical-warning-nov-26/) |
 | [ExpensiveWall](2017/expensivewall.md) | 2017 | Dev Tooling | [1](https://blog.checkpoint.com/2017/09/14/expensivewall-dangerous-packed-malware-google-play-will-hit-wallet/), [2](https://research.checkpoint.com/expensivewall-dangerous-packed-malware-google-play-will-hit-wallet/)
 | [OSX Elmedia player](2017/elmedia.md) | 2017 | Publishing infrastructure | [1](https://www.hackread.com/hackers-infect-mac-users-proton-malware-using-elmedia-player/) |
-| [GitHub password recovery issues](2016/gh-unicode.md) | 2016 | Dev Tool <br> Source Code </br> | [1](https://bounty.github.com/researchers/jagracey.html), [2](https://eng.getwisdom.io/hacking-github-with-unicode-dotless-i/) |
+| [GitHub password recovery issues](2016/gh-unicode.md) | 2016 | Dev Tool <br> Source Code </br> | [1](https://bounty.github.com/researchers/jagracey.html), [2](https://dev.to/jagracey/hacking-github-s-auth-with-unicode-s-turkish-dotless-i-460n) |
 | [keydnap](2016/keydnap.md) | 2016 | Publishing infrastructure | [1](https://blog.malwarebytes.com/threat-analysis/2016/09/transmission-hijacked-again-to-spread-malware), [2](https://www.welivesecurity.com/2016/08/30/osxkeydnap-spreads-via-signed-transmission-application/) |
 | [Fosshub Breach](2016/fosshub.md) | 2016 | Publishing infrastructure | [1](https://www.ghacks.net/2016/08/03/attention-fosshub-downloads-compromised/), [2](https://www.theregister.co.uk/2016/08/04/classicshell_audicity_infection/) |
 | [Linux Mint](2016/mint.md) | 2016 | Publishing infrastructure | [1](https://www.zdnet.com/article/linux-mint-website-hacked-malicious-backdoor-version/) |

--- a/supply-chain-security/compromises/README.md
+++ b/supply-chain-security/compromises/README.md
@@ -30,6 +30,7 @@ of compromise needs added, please include that as well.
 <!-- cSpell:disable -->
 | Name              | Year               | Type of compromise    | Link        |
 | ----------------- | ------------------ | ------------------    | ----------- |
+| [Compromise of NP packages coa and rc](2021/coa-rc.md) | 2021 | Malicious Maintainer | [1](https://blog.sonatype.com/npm-hijackers-at-it-again-popular-coa-and-rc-open-source-libraries-taken-over-to-spread-malware) |
 | [Compromise of ua-parser-js](2021/ua-parser-js.md) | 2021 | Malicious Maintainer | [1](https://github.com/faisalman/ua-parser-js/issues/536) |
 | [The klow / klown / okhsa incident](2021/klow-klown-okhsa.md) | 2021 |  | [1](https://blog.sonatype.com/newly-found-npm-malware-mines-cryptocurrency-on-windows-linux-macos-devices) |
 | [PHP self-hosted git server](2021/php.md) | 2021 | Dev Tooling | [1](https://news-web.php.net/php.internals/113838) |

--- a/supply-chain-security/compromises/README.md
+++ b/supply-chain-security/compromises/README.md
@@ -30,6 +30,8 @@ of compromise needs added, please include that as well.
 <!-- cSpell:disable -->
 | Name              | Year               | Type of compromise    | Link        |
 | ----------------- | ------------------ | ------------------    | ----------- |
+| [Compromise of ua-parser-js](2021/ua-parser-js.md) | 2021 | Malicious Maintainer | [1](https://github.com/faisalman/ua-parser-js/issues/536) |
+| [The klow / klown / okhsa incident](2021/klow-klown-okhsa.md) | 2021 |  | [1](https://blog.sonatype.com/newly-found-npm-malware-mines-cryptocurrency-on-windows-linux-macos-devices) |
 | [PHP self-hosted git server](2021/php.md) | 2021 | Dev Tooling | [1](https://news-web.php.net/php.internals/113838) |
 | [Homebrew](2021/homebrew.md) | 2021 | Dev Tooling | [1](https://brew.sh/2021/04/21/security-incident-disclosure/), [2](https://hackerone.com/reports/1167608) |  |
 | [Codecov](2021/codecov.md) | 2021 | Source Code | [1](https://about.codecov.io/security-update/) |  |


### PR DESCRIPTION
I'm a little unclear which compromise-definition applies to the klow/klown/okhsa situation, since they seem to have been new packages. I've added them separately because of the connection to ua-parser-js.