### PR TITLE
Updating kubecon event in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ If you are new, check out the [New Members Page](/NEW-MEMBERS.md).
 
 - Marlow Weston ([@catblade](https://github.com/catblade)), Intel
 - Pushkar Joglekar ([@pushkarj](https://github.com/pushkarj))
-- POP ([@danpopsd](https://github.com/danpopsd)), Sysdig
+- POP ([@danpopnyc](https://github.com/danpopnyc)), Sysdig
 - Devarajan P Ramaswamy ([@deva](https://github.com/deva26)), PADME
 - Kamil Pawlowski ([@kbpawlowski](https://github.com/kbpawlowski))
 - Geri Jennings ([@izgeri](https://github.com/izgeri)), CyberArk

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ helping to organize!) a gathering. Create a [github
 issue](https://github.com/cncf/tag-security/issues/new) for an event and add to
 list below:
 
-- KubeCon + CloudNativeCon, NA October 12-15 2021
+- KubeCon + CloudNativeCon, Europe May 16-20 2022
 
 [Past events](past-events.md)
 

--- a/cloud_native_security.md
+++ b/cloud_native_security.md
@@ -17,7 +17,36 @@ project, architecture, and enhance team awareness on security.
 
 ## References to past events & related issues that have details of planning
 
+### 2018
+
+[KubeCon EU 2018](https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2018/)
+
+- Copenhagen, Denmark
+- May 2-4, 2018
+- [notes](safe_kubecon.md)
+
+[KubeCon + CloudNativeCon, Shanghai](https://events19.linuxfoundation.cn/events/kubecon-cloudnativecon-china-2018/)
+
+- Shanghai, China
+- Nov 14-15, 2018
+- Planning the event =>
+  [issue#28](https://github.com/cncf/tag-security/issues/28)
+
+[KubeCon + CloudNativeCon, North America](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2018/)
+
+- Seattle, USA
+- December 11-13, 2018
+- Planning the event =>
+  [issue#29](https://github.com/cncf/tag-security/issues/29)
+
 ### 2019
+
+[KubeCon + CloudNativeCon + Open Source Summit](https://events19.linuxfoundation.cn/events/kubecon-cloudnativecon-china-2019/)
+
+- Shanghai, China
+- June 24-26, 2019
+- Planning the event =>
+  [issue#200](https://github.com/cncf/tag-security/issues/200)
 
 [Cloud Native Security Day NA](https://events19.linuxfoundation.org/events/cloud-native-security-day-2019/)
 

--- a/past-events.md
+++ b/past-events.md
@@ -1,28 +1,55 @@
 # Past Events
 
+<!— cSpell:ignore raycolline —>
+<!— cSpell:ignore tsandall —>
+<!— cSpell:ignore timothyhinrichs —>
+<!— cSpell:ignore sreetummidi —>
+
 A list of past KubeCon/Cloud Native Security Day events an be found [here](cloud_native_security.md)
 
 ## DockerCon, San Francisco, CA, Apr 30 - May 2, 2019
+
 [issue#151](https://github.com/cncf/tag-security/issues/151)
 
 ### TAG talks
-- [CNCF TAG-Security Intro](https://kccnceu19.sched.com/event/OB0K/intro-cncf-security-tag-sarah-allen-jeyappragash-jeyakeerthi-tetrateio) -  [slides](https://docs.google.com/presentation/d/1KE2tDDOeEOXQLF6hSrAuQLn4z25O_jeHIeAVE4CB-VI/edit#slide=id.gc6fa3c898_0_70) | [video](https://www.youtube.com/watch?v=XD89-v3oWPE)
-- [CNCF TAG-Security Deep Dive](https://kccnceu19.sched.com/event/Oscd/deep-dive-cncf-security-tag-justin-cappos-new-york-university-zhipeng-huang-huawei) - [slides](https://docs.google.com/presentation/d/18nzXspPuRDRKfGUSI1ogFHmUOP_XHS78nz-0uTG9Ogs/edit?usp=sharing) | [video](https://www.youtube.com/watch?v=EF3nl80kpm4)
-- [Inside CNCF Project Security Reviews](https://kccnceu19.sched.com/event/MPdf/inside-the-cncf-project-security-reviews-justin-cormack-docker) - [video](https://www.youtube.com/watch?v=0BkKpsrUo5k)
+
+- [CNCF TAG-Security Intro](https://kccnceu19.sched.com/event/OB0K/intro-cncf-security-tag-sarah-allen-jeyappragash-jeyakeerthi-tetrateio)
+\-  [slides](https://docs.google.com/presentation/d/1KE2tDDOeEOXQLF6hSrAuQLn4z25O_jeHIeAVE4CB-VI/edit#slide=id.gc6fa3c898_0_70)
+| [video](https://www.youtube.com/watch?v=XD89-v3oWPE)
+
+- [CNCF TAG-Security Deep Dive](https://kccnceu19.sched.com/event/Oscd/deep-dive-cncf-security-tag-justin-cappos-new-york-university-zhipeng-huang-huawei)
+\- [slides](https://docs.google.com/presentation/d/18nzXspPuRDRKfGUSI1ogFHmUOP_XHS78nz-0uTG9Ogs/edit?usp=sharing)
+| [video](https://www.youtube.com/watch?v=EF3nl80kpm4)
+- [Inside CNCF Project Security Reviews](https://kccnceu19.sched.com/event/MPdf/inside-the-cncf-project-security-reviews-justin-cormack-docker)
+\- [video](https://www.youtube.com/watch?v=0BkKpsrUo5k)
 
 ### Misc security-related talks
-- [Intro: TUF/Notary](https://docs.google.com/presentation/d/1Mp4pSMEvZIv0qo6wBWm-4vM6CZ-0IXimpq8zD3iTH0Q/edit#slide=id.g5a645bebe8_0_921) - [video](https://www.youtube.com/watch?v=gIFRQObHbZk)
-- [Deep Dive: TUF/Notary](https://kccnceu19.sched.com/event/MPkF/deep-dive-tuf-notary-justin-cappos-lukas-puehringer-nyu) - [video](https://www.youtube.com/watch?v=PSujE86JvBk)
-- [Intro: SPIFFE](https://kccnceu19.sched.com/event/MPib/intro-spiffe-emiliano-bernbaum-scott-emmons-scytale) - [video](https://www.youtube.com/watch?v=Rx6PMptyEtg)
-- [Deep Dive: SPIFFE](https://kccnceu19.sched.com/event/MPk9/deep-dive-spiffe-scott-emmons-emiliano-bernbaum-scytale) - [video](https://www.youtube.com/watch?v=OHiPsqT1gcI)
-- [Intro: Open Policy Agent](https://kccnceu19.sched.com/event/MPiM/intro-open-policy-agent-rita-zhang-microsoft-max-smythe-google) - [video](https://www.youtube.com/watch?v=Yup1FUc2Qn0)
-- [Deep Dive: Open Policy Agent](https://kccnceu19.sched.com/event/MPk0/deep-dive-open-policy-agent-torin-sandall-tim-hinrichs-styra) - [video](https://www.youtube.com/watch?v=n94_FNhuzy4)
-- [Secrets Store CSI Driver-Bring Your Own Enterprise Secrets Store to K8s](https://kccnceu19.sched.com/event/MPdZ/secrets-store-csi-driver-bring-your-own-enterprise-secrets-store-to-k8s-rita-zhang-microsoft-anubhav-mishra-hashicorp) - [video](https://www.youtube.com/watch?v=bIC4kLnrKN0)
-- [Protecting the Data Lake with OPA](https://sched.co/MPdu) - [slides](https://drive.google.com/file/d/1NVKn88EoRAzi_Kd5KGPfOjd6fZpLhjJE/view?usp=sharing) | [video](https://www.youtube.com/watch?v=9m4FymEvOqM)
-- [Securing Kubernetes with Trusted Platform Module (TPM)](https://kccnceu19.sched.com/event/MPdN/securing-kubernetes-with-trusted-platform-module-tpm-alex-tcherniakhovski-andrew-lytvynov-google) - [slides](https://static.sched.com/hosted_files/kccnceu19/a9/Securing%20Kubernetes%20with%20Trusted%20Platform%20Module.pdf) | [video](https://www.youtube.com/watch?v=_kxmkI8Kc8Y)
-- [Uber x Security: Why and How We Built Our Workload Identity Platform](https://kccnceu19.sched.com/event/MPe6) - [slides](https://static.sched.com/hosted_files/kccnceu19/bf/slides-julian-feldman.pdf) | [video](https://www.youtube.com/watch?v=JKkq60DvPBw)
 
-# Past Meetings
+- [Intro: TUF/Notary](https://docs.google.com/presentation/d/1Mp4pSMEvZIv0qo6wBWm-4vM6CZ-0IXimpq8zD3iTH0Q/edit#slide=id.g5a645bebe8_0_921)
+\- [video](https://www.youtube.com/watch?v=gIFRQObHbZk)
+- [Deep Dive: TUF/Notary](https://kccnceu19.sched.com/event/MPkF/deep-dive-tuf-notary-justin-cappos-lukas-puehringer-nyu)
+\- [video](https://www.youtube.com/watch?v=PSujE86JvBk)
+- [Intro: SPIFFE](https://kccnceu19.sched.com/event/MPib/intro-spiffe-emiliano-bernbaum-scott-emmons-scytale)
+\- [video](https://www.youtube.com/watch?v=Rx6PMptyEtg)
+- [Deep Dive: SPIFFE](https://kccnceu19.sched.com/event/MPk9/deep-dive-spiffe-scott-emmons-emiliano-bernbaum-scytale)
+\- [video](https://www.youtube.com/watch?v=OHiPsqT1gcI)
+- [Intro: Open Policy Agent](https://kccnceu19.sched.com/event/MPiM/intro-open-policy-agent-rita-zhang-microsoft-max-smythe-google)
+\- [video](https://www.youtube.com/watch?v=Yup1FUc2Qn0)
+- [Deep Dive: Open Policy Agent](https://kccnceu19.sched.com/event/MPk0/deep-dive-open-policy-agent-torin-sandall-tim-hinrichs-styra)
+\- [video](https://www.youtube.com/watch?v=n94_FNhuzy4)
+- [Secrets Store CSI Driver-Bring Your Own Enterprise Secrets Store to K8s](https://kccnceu19.sched.com/event/MPdZ/secrets-store-csi-driver-bring-your-own-enterprise-secrets-store-to-k8s-rita-zhang-microsoft-anubhav-mishra-hashicorp)
+\- [video](https://www.youtube.com/watch?v=bIC4kLnrKN0)
+- [Protecting the Data Lake with OPA](https://sched.co/MPdu)
+\- [slides](https://drive.google.com/file/d/1NVKn88EoRAzi_Kd5KGPfOjd6fZpLhjJE/view?usp=sharing)
+| [video](https://www.youtube.com/watch?v=9m4FymEvOqM)
+- [Securing Kubernetes with Trusted Platform Module (TPM)](https://kccnceu19.sched.com/event/MPdN/securing-kubernetes-with-trusted-platform-module-tpm-alex-tcherniakhovski-andrew-lytvynov-google)
+\- [slides](https://static.sched.com/hosted_files/kccnceu19/a9/Securing%20Kubernetes%20with%20Trusted%20Platform%20Module.pdf)
+| [video](https://www.youtube.com/watch?v=_kxmkI8Kc8Y)
+- [Uber x Security: Why and How We Built Our Workload Identity Platform](https://kccnceu19.sched.com/event/MPe6)
+\- [slides](https://static.sched.com/hosted_files/kccnceu19/bf/slides-julian-feldman.pdf)
+| [video](https://www.youtube.com/watch?v=JKkq60DvPBw)
+
+## Past Meetings
 
 <details><summary>Click to view list</summary>
 
@@ -45,73 +72,100 @@ A list of past KubeCon/Cloud Native Security Day events an be found [here](cloud
 * [2019-06-05 CNCF TAG-Security Meeting](https://docs.google.com/document/d/170y5biX9k95hYRwprITprG6Mc9xD5glVn-4mB2Jmi2g/edit)
 * [2019-05-29 CNCF TAG-Security Meeting](https://docs.google.com/document/d/170y5biX9k95hYRwprITprG6Mc9xD5glVn-4mB2Jmi2g/edit)
 * 2019-05-22 CNCF TAG-Security Meeting - No Meeting due to KubeCon Europe
-* [2019-05-15 CNCF TAG-Security Meeting](https://docs.google.com/document/d/170y5biX9k95hYRwprITprG6Mc9xD5glVn-4mB2Jmi2g/edit)  - OPA with SAFE Presentation Framework
+* [2019-05-15 CNCF TAG-Security Meeting](https://docs.google.com/document/d/170y5biX9k95hYRwprITprG6Mc9xD5glVn-4mB2Jmi2g/edit)
+\- OPA with SAFE Presentation Framework
 * [2019-05-08 CNCF TAG-Security Meeting](https://docs.google.com/document/d/170y5biX9k95hYRwprITprG6Mc9xD5glVn-4mB2Jmi2g/edit)
 * [2019-04-12 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
-* [2019-04-11 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit) - Working Session
-* [2019-04-05 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit) - Google Open Source Project Onboarding
-* [2019-04-04 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit) - Working Session
-* [2019-03-29 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit) - Revised presentation framework with in-toto (OPA, Kamus, TOC invited)
-* [2019-03-28 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit) - Working Session
+* [2019-04-11 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+\- Working Session
+* [2019-04-05 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+\- Google Open Source Project Onboarding
+* [2019-04-04 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+\- Working Session
+* [2019-03-29 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+\- Revised presentation framework with in-toto (OPA, Kamus, TOC invited)
+* [2019-03-28 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+\- Working Session
 * [2019-03-22 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
-* [2019-03-22 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit) - SAFE Whitepaper Working Session
+* [2019-03-22 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+\- SAFE Whitepaper Working Session
 * [2019-03-15 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
 * [2019-03-08 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
-* [2019-03-07 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit) - Working Session
+* [2019-03-07 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+\- Working Session
 * [2019-03-08 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
-* [2019-03-07 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit) - Working Session
+* [2019-03-07 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+\- Working Session
 * [2019-03-01 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
-* [2019-02-28 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit) - Working Session
+* [2019-02-28 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+\- Working Session
 * [2019-02-22 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
-* [2019-02-21 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit) - Working Session
+* [2019-02-21 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+\- Working Session
 * [2019-02-15 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
 * [2019-02-08 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
 * [2019-02-01 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
-* [2019-01-31 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit) - Working Session
+* [2019-01-31 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+\- Working Session
 * [2019-01-25 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
-* [2019-01-24 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit) - Working Session
+* [2019-01-24 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+\- Working Session
 * [2019-01-18 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
-* [2019-01-17 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit) - Working Session
+* [2019-01-17 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+\- Working Session
 * [2019-01-11 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
-* [2019-01-10 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit) - Working Session - :star: [new meeting notes doc](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+* [2019-01-10 SAFE Meeting](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
+\- Working Session - :star: [new meeting notes doc](https://docs.google.com/document/d/1WLnEErqODywjkQVTAESpwK8pgIbxsNDp6SqOtw3kjlk/edit)
 * [2018-12-21 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
 * [2018-12-13 SAFE WG BOF Deep Dive @ KubeCon + CloudNativeCon North America 2018](https://kccna18.sched.com/event/GrdR/deep-dive-safe-bof-jeyappragash-jeyakeerthi-padmeio-dan-shaw-danshaw-llc)
 * 2018-12-11 SAFE WG Dinner @ KubeCon + CloudNativeCon North America 2018
-* [2018-12-11 SAFE WG BOF Intro @ KubeCon + CloudNativeCon North America 2018](https://kccna18.sched.com/event/GrbV/intro-safe-bof-jeyappragash-jeyakeerthi-padmeio-dan-shaw-danshaw-llc)
+* [2018-12-11 SAFE WG BOF Intro @ KubeCon + CloudNativeCon North America
+2018](https://kccna18.sched.com/event/GrbV/intro-safe-bof-jeyappragash-jeyakeerthi-padmeio-dan-shaw-danshaw-llc)
 * [2018-12-14 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
 * [2018-12-07 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
 * [2018-11-30 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
-* [2018-11-29 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit) - Working Session
+* [2018-11-29 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
+\- Working Session
 * 2018-11-23 - no meeting
 * 2018-11-22 - no meeting :turkey:
 * [2018-11-16 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
-* [2018-11-15 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit) - Working Session
-* 2018-11-14 - KubeCon Shanghai 2018 Intro Session: [Intro: SAFE (A Cloud Native Security Working Group)](https://kccncchina2018english.sched.com/event/FuLG)
+* [2018-11-15 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
+\- Working Session
+* 2018-11-14 - KubeCon Shanghai 2018 Intro Session:
+[Intro: SAFE (A Cloud Native Security Working Group)](https://kccncchina2018english.sched.com/event/FuLG)
 * 2018-11-09 - no meeting: [SPIFFE Community Day](https://docs.google.com/document/d/1Gt91uPgemRuW56P3qnuQfs0VoWn_2n0D8N-LxpnUu5c/edit)
-* [2018-11-08 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit) - Working Session
+* [2018-11-08 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
+\- Working Session
 * [2018-10-26 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
-* [2018-10-25 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit) - Working Session
+* [2018-10-25 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
+\- Working Session
 * [2018-10-19 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
 * [2018-10-12 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
 * [2018-10-05 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
-* [2018-10-04 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit) - Working Session
+* [2018-10-04 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
+\- Working Session
 * [2018-09-28 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
 * [2018-09-21 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
-* [2018-09-20 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit) - Working Session
+* [2018-09-20 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
+\- Working Session
 * [2018-09-14 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
 * [2018-09-07 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
-* [2018-09-06 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit) - Working Session
+* [2018-09-06 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
+\- Working Session
 * [2018-08-31 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
 * [2018-08-31 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
 * [2018-08-30 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
 * [2018-08-24 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
-* 2018-08-21 SAFE WG proposal to the CNCCF TOC
+* 2018-08-21 SAFE WG proposal to the CNCF TOC
 * [2018-08-17 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
-* [2018-08-16 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit) - Working Session
+* [2018-08-16 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
+\- Working Session
 * [2018-08-10 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
-* [2018-08-09 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit) - Working Session
+* [2018-08-09 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
+\- Working Session
 * [2018-08-03 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
-* [2018-08-02 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit) - Working Session
+* [2018-08-02 SAFE Meeting](https://docs.google.com/document/d/1JsEv4vk_61UaF9SaHBRzzPGja-bNsHeLqxa53RPVfos/edit)
+\- Working Session
 * [2018-07-27 SAFE Meeting](https://docs.google.com/document/d/1DqqeTguBpalPj-y4nqY0uo8vYn_tU6DJzmbIdoyslhw/edit)
 * [2018-07-13 SAFE Meeting](https://docs.google.com/document/d/1sniqXFFcP4vpX2bO6NeB31mzO1YOJrcQy2ryXATSHmk/edit)
 * [2018-06-29 SAFE Meeting](https://docs.google.com/document/d/1fyBDIm82xtTYWhZu3gyLahltMdTOxl9aWfOfRxYHapo/edit)
@@ -124,16 +178,24 @@ A list of past KubeCon/Cloud Native Security Day events an be found [here](cloud
 * KubeCon Europe 2018 Deep-dive Session
 * KubeCon Europe 2018 Intro Session
 * [2018-04-27 SAFE Meeting](https://docs.google.com/document/d/1mtdBg6-8eGgBCfIFT56dDe_LVRCw5_tSeIAsRH_8KfM/edit)
-* [2018-04-20 SAFE Meeting](https://docs.google.com/document/d/1B7G0_V1i8DTX-JIzMquUzFJgJBzZN-NWkJDCi62LOh4/edit) - CNCF TOC Proposal follow-up
-* [2018-04-13 SAFE Meeting](https://docs.google.com/document/d/1SVPJzQrEpBixugI1Kjww90RxhaOovdNhWtWb3LsSjYU/edit) - Prep for the SAFE WG proposal presentation to the CNCF TOC on 4/17
-* [2018-04-06 SAFE Meeting](https://docs.google.com/document/d/1a_a0dUTdSERgHiAnbUL0r2PNvbTe0SWHmYh7yFhTiFk/edit) - SAFE Personas WhitePaper
+* [2018-04-20 SAFE Meeting](https://docs.google.com/document/d/1B7G0_V1i8DTX-JIzMquUzFJgJBzZN-NWkJDCi62LOh4/edit)
+\- CNCF TOC Proposal follow-up
+* [2018-04-13 SAFE Meeting](https://docs.google.com/document/d/1SVPJzQrEpBixugI1Kjww90RxhaOovdNhWtWb3LsSjYU/edit)
+\- Prep for the SAFE WG proposal presentation to the CNCF TOC on 4/17
+* [2018-04-06 SAFE Meeting](https://docs.google.com/document/d/1a_a0dUTdSERgHiAnbUL0r2PNvbTe0SWHmYh7yFhTiFk/edit)
+\- SAFE Personas WhitePaper
 * [2018-03-30 SAFE Meeting](https://docs.google.com/document/d/1KwqAlBpb8TAex4_ABFmxpPZq9-MPvK3kraLUW9ws1EE/edit)
-* [2018-03-23 SAFE Meeting](https://docs.google.com/document/d/1H3VOI9-GqRAj_tdPL9sECF1c8t4x_sF1G08PqLzlUWM/edit) - NIST Big Data public working group - security and privacy subgroup with Mark Underwood
+* [2018-03-23 SAFE Meeting](https://docs.google.com/document/d/1H3VOI9-GqRAj_tdPL9sECF1c8t4x_sF1G08PqLzlUWM/edit)
+\- NIST Big Data public working group - security and privacy subgroup with Mark Underwood
 * [2018-03-16 SAFE Meeting](https://docs.google.com/document/d/1nYN3cy7jrKQbEziT43447w8ZValOuioxEKYE0D4vkPU/edit)
 * 2018-03-09 - no meeting
-* [2018-03-02 SAFE Meeting](https://docs.google.com/document/d/1vZfDHLh2jy0uH_U_qLpbp64Xy64gu0SrgVLJov4kuMw/edit) - GCP Administrators Bill of Rights with [@raycolline](https://github.com/raycolline)
-* [2018-02-23 SAFE Meeting](https://docs.google.com/document/d/1U4x1wynL-JlojF1Qidus97t8bJve3XJWTpc07hHCAxU/edit) - Open Policy Agent (OPA) Use Case with [@tsandall](https://github.com/tsandall) and [@timothyhinrichs](https://github.com/timothyhinrichs)
-* [2018-02-16 SAFE Meeting](https://docs.google.com/document/d/1aAldFgdU6EhtmQWCFMefFMaevKumDe08wMlfoCt9mFw/edit) - Cloud Foundry Use Case with [@sreetummidi](https://github.com/sreetummidi)
+* [2018-03-02 SAFE Meeting](https://docs.google.com/document/d/1vZfDHLh2jy0uH_U_qLpbp64Xy64gu0SrgVLJov4kuMw/edit)
+\- GCP Administrators Bill of Rights with [@raycolline](https://github.com/raycolline)
+* [2018-02-23 SAFE Meeting](https://docs.google.com/document/d/1U4x1wynL-JlojF1Qidus97t8bJve3XJWTpc07hHCAxU/edit)
+\- Open Policy Agent (OPA) Use Case with [@tsandall](https://github.com/tsandall)
+and [@timothyhinrichs](https://github.com/timothyhinrichs)
+* [2018-02-16 SAFE Meeting](https://docs.google.com/document/d/1aAldFgdU6EhtmQWCFMefFMaevKumDe08wMlfoCt9mFw/edit)
+\- Cloud Foundry Use Case with [@sreetummidi](https://github.com/sreetummidi)
 * [2018-02-07 SAFE Meeting](https://docs.google.com/document/d/1Z30hfVquiRz9dIjek0Tcg540LuX3D4TPhJ3UWpDMltU/edit)
-</details>
 
+</details>

--- a/past-events.md
+++ b/past-events.md
@@ -1,28 +1,9 @@
 # Past Events
 
-## KubeCon + CloudNativeCon, Barcelona, Spain, May 20 – 23, 2019
-
-[issue#127](https://github.com/cncf/tag-security/issues/127)
-
-## KubeCon + CloudNativeCon + Open Source Summit, Shanghai, Jun 24-26, 2019
-
-[issue#200](https://github.com/cncf/tag-security/issues/200)
+A list of past KubeCon/Cloud Native Security Day events an be found [here](cloud_native_security.md)
 
 ## DockerCon, San Francisco, CA, Apr 30 - May 2, 2019
 [issue#151](https://github.com/cncf/tag-security/issues/151)
-
-## KubeCon + CloudNativeCon, North America, Dec 11-13, 2018
-
-[issue#29](https://github.com/cncf/tag-security/issues/29)
-
-## KubeCon + CloudNativeCon, Shanghai, Nov 14-15, 2018
- [issue#28](https://github.com/cncf/tag-security/issues/28)
-
-## KubeConEU May 2-4, 2018 in Copenhagen, Denmark
-
-https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2018/
-
-[notes](safe_kubecon.md)
 
 ### TAG talks
 - [CNCF TAG-Security Intro](https://kccnceu19.sched.com/event/OB0K/intro-cncf-security-tag-sarah-allen-jeyappragash-jeyakeerthi-tetrateio) -  [slides](https://docs.google.com/presentation/d/1KE2tDDOeEOXQLF6hSrAuQLn4z25O_jeHIeAVE4CB-VI/edit#slide=id.gc6fa3c898_0_70) | [video](https://www.youtube.com/watch?v=XD89-v3oWPE)

--- a/past-events.md
+++ b/past-events.md
@@ -50,7 +50,7 @@ A list of past KubeCon/Cloud Native Security Day events an be found [here](cloud
 | [video](https://www.youtube.com/watch?v=JKkq60DvPBw)
 
 ## Past Meetings
-
+<!-- markdownlint-disable-next-line -->
 <details><summary>Click to view list</summary>
 
 * [2019-09-25 CNCF TAG-Security Meeting](https://docs.google.com/document/d/170y5biX9k95hYRwprITprG6Mc9xD5glVn-4mB2Jmi2g/edit)
@@ -190,7 +190,7 @@ A list of past KubeCon/Cloud Native Security Day events an be found [here](cloud
 * [2018-03-16 SAFE Meeting](https://docs.google.com/document/d/1nYN3cy7jrKQbEziT43447w8ZValOuioxEKYE0D4vkPU/edit)
 * 2018-03-09 - no meeting
 * [2018-03-02 SAFE Meeting](https://docs.google.com/document/d/1vZfDHLh2jy0uH_U_qLpbp64Xy64gu0SrgVLJov4kuMw/edit)
-\- GCP Administrators Bill of Rights with [@raycolline](https://github.com/raycolline)
+\- GCP Administrators Bill of Rights with @raycolline
 * [2018-02-23 SAFE Meeting](https://docs.google.com/document/d/1U4x1wynL-JlojF1Qidus97t8bJve3XJWTpc07hHCAxU/edit)
 \- Open Policy Agent (OPA) Use Case with [@tsandall](https://github.com/tsandall)
 and [@timothyhinrichs](https://github.com/timothyhinrichs)


### PR DESCRIPTION
Also moved prior CN security days to the cloud_native_security.md from
past-events.md, and linked to that doc so things are in one place.