### PR TITLE
What: Create TL Transition checklist (#847)

### DIFF
--- a/governance/tech-lead-transition.md
+++ b/governance/tech-lead-transition.md
@@ -10,7 +10,7 @@ For nomination process please refer to [tech-lead-proposal-process](./tech-lead-
 
 * [ ] Transfer Logistics
   * [ ] #tag-security-chairs-and-tech-leads channel - add new TL(s)
-  * [ ] [tag-leadership mailing list](https://lists.cncf.io/g/cncf-tag-security-leads) - add new TL(s)
+  * [ ] tag-leadership mailing list - add new TL(s)
   * [ ] add TL to chairs/leads meeting
   * [ ] add TL to [github team](https://github.com/orgs/cncf/teams/tag-security/)
   * [ ] tag-security repo PR:

--- a/governance/tech-lead-transition.md
+++ b/governance/tech-lead-transition.md
@@ -1,0 +1,32 @@
+# Tech Lead transition checklist
+
+This checklist should be copied into a new issue for when a new tech lead(s) is needed.
+
+## Nomination
+
+For nomination process please refer to [tech-lead-proposal-process](./tech-lead-proposal-process.md)
+
+## Transfer
+
+* [ ] Transfer Logistics
+  * [ ] #tag-security-chairs-and-tech-leads channel - add new TL(s)
+  * [ ] [tag-leadership mailing list](https://lists.cncf.io/g/cncf-tag-security-leads) - add new TL(s)
+  * [ ] add TL to chairs/leads meeting
+  * [ ] add TL to [github team](https://github.com/orgs/cncf/teams/tag-security/)
+  * [ ] tag-security repo PR:
+    * [ ] Update codeowners, github settings, README (TOC Liaisons and chairs
+      have admin access, tech leads have push access).
+    * [ ] Link to official vote email list message in PR descriptions
+    * [ ] Add STAG milestone to track STAG rep for TL
+  * [ ] Verify new TLs have zoom credentials
+  * [ ] Introduce new TL selection, in the next steering committee meeting slide
+  * [ ] YouTube Channel
+    * [ ] invite new TLs (if needed)
+    * [ ] give "managers" permission
+
+## Announce
+
+* [ ] Announce the vote
+  * [ ] #tag-security slack message
+  * [ ] email message to the tag-security list
+  * [ ] Security TAG meeting Announcement for each region


### PR DESCRIPTION
Why:

* Address issue TL Transition Checklist #847 in order to provide continuity and consistency

This change addresses the need by:

* Documenting the checklist created from issue TL Transition Checklist #847 for reuse.