### PR TITLE
compromises: 2022 - node-ipc

### DIFF
--- a/supply-chain-security/compromises/2022/js-faker-colors.md
+++ b/supply-chain-security/compromises/2022/js-faker-colors.md
@@ -12,7 +12,7 @@ A few weeks after this incident, it was announced that the [Top-100 npm package 
 
 ## Type of Compromise
 
-This incident fits the [malicious maintainer](compromise-definitions.md#malicious-maintainer) definition.
+This incident fits the [malicious maintainer](../compromise-definitions.md#malicious-maintainer) definition.
 
 ## References
 

--- a/supply-chain-security/compromises/2022/node-ipc-peacenotwar.md
+++ b/supply-chain-security/compromises/2022/node-ipc-peacenotwar.md
@@ -1,0 +1,24 @@
+<!-- cspell:ignore peacenotwar -->
+# npm Library ‘node-ipc’ Sabotaged with npm Library ‘peacenotwar’ in Protest by their Maintainer
+
+The author of these `npm` libraries intentionally committed corrupt versions containing obfuscated code that would dump a file to your desktop and rewrite files based IP address geographical origin.
+
+## Impact
+
+This incident affected a medium but unknown number of users and impacting large downstream projects such as `@vue/cli`.
+
+It triggered some discussion around maintainer reputation and what action to take around the maintainer's other popular libraries with a combined 4 million downloads (excluding `node-ipc`'s 1 million):
+
+- `js-queue`
+- `easy-stack`
+- `js-message`
+- `node-cmd`
+
+## Type of Compromise
+
+This incident fits the [malicious maintainer](../compromise-definitions.md#malicious-maintainer) definition.
+
+## References
+
+- [Alert: peacenotwar module sabotages npm developers in the node-ipc package to protest the invasion of Ukraine](https://snyk.io/blog/peacenotwar-malicious-npm-node-ipc-package-vulnerability/)
+- [CVE-2022-23812 | RIAEvangelist/node-ipc is malware / protest-ware](https://gist.github.com/MidSpike/f7ae3457420af78a54b38a31cc0c809c)

--- a/supply-chain-security/compromises/README.md
+++ b/supply-chain-security/compromises/README.md
@@ -30,6 +30,7 @@ of compromise needs added, please include that as well.
 <!-- cSpell:disable -->
 | Name              | Year               | Type of compromise    | Link        |
 | ----------------- | ------------------ | ------------------    | ----------- |
+| [npm Library ‘node-ipc’ Sabotaged with npm Library ‘peacenotwar’ in Protest by their Maintainer](2022/node-ipc-peacenotwar.md) | 2022 | Malicious Maintainer | [1](https://snyk.io/blog/peacenotwar-malicious-npm-node-ipc-package-vulnerability/)|
 | [npm Libraries ‘colors’ and ‘faker’ Sabotaged in Protest by their Maintainer](2022/js-faker-colors.md) | 2022 | Malicious Maintainer | [1](https://www.revenera.com/blog/software-composition-analysis/the-story-behind-colors-js-and-faker-js/)|
 | [GCP Golang Buildpacks Old Compiler Injection](2022/golang-buildpacks-compiler.md) | 2022 | Source Code | [1](https://zt.dev/posts/gcp-buildpacks-old-compiler/)|
 | [WordPress theme publisher compromised](2022/wp-apthemes.md) | 2022 | Source Code | [1](https://jetpack.com/2022/01/18/backdoor-found-in-themes-and-plugins-from-accesspress-themes/), [2](https://blog.sucuri.net/2022/01/accesspress-themes-hit-with-targeted-supply-chain-attack.html)|

--- a/supply-chain-security/compromises/README.md
+++ b/supply-chain-security/compromises/README.md
@@ -65,7 +65,7 @@ of compromise needs added, please include that as well.
 | [Colourama](2018/colourama.md) | 2018 | Negligence | [1](https://medium.com/@bertusk/cryptocurrency-clipboard-hijacker-discovered-in-pypi-repository-b66b8a534a8), [2](https://arstechnica.com/information-technology/2018/10/two-new-supply-chain-attacks-come-to-light-in-less-than-a-week/) |
 | [Foxif/CCleaner](2017/ccleaner.md) | 2017 | Publishing Infrastructure | [1](https://blog.talosintelligence.com/2017/09/avast-distributes-malware.html) |
 | [HandBrake](2017/handbrake.md) | 2017 | Publishing Infrastructure | [1](https://blog.malwarebytes.com/threat-analysis/mac-threat-analysis/2017/05/handbrake-hacked-to-drop-new-variant-of-proton-malware/) |
-| [Kingslayer](2017/kingslayer.md) | 2017 | Publishing Infrastructure | [1](https://www.rsa.com/content/dam/premium/en/white-paper/kingslayer-a-supply-chain-attack.pdf) |
+| [Kingslayer](2017/kingslayer.md) | 2017 | Publishing Infrastructure | [1](https://comsecglobal.com/kingslayer-a-supply-chain-attack/) |
 | [HackTask](2017/hacktask.md) | 2017 | Negligence | [1](https://securityintelligence.com/news/typosquatting-attack-puts-developers-at-risk-from-infected-javascript-packages/) |
 | [NotPetya](2017/notpetya.md) | 2017 | Attack Chaining | [1](https://www.welivesecurity.com/2017/07/04/analysis-of-telebots-cunning-backdoor/) |
 | [Bitcoin Gold](2017/bitcoingold.md) | 2017 | Source Code | [1](https://bitcoingold.org/critical-warning-nov-26/) |


### PR DESCRIPTION
Adds node-ipc/peacenotwar compromise

This post is strongly based on the existing `2022/js-faker-colors.md`

I'm looking for guidance around the amount of users affected. NPM downloads was stopped just short of 43k downloads. I've just changed it to "medium" for now.
Also there's the limiting factor of the rewriting only being for specific IPs but AFAIK the text file is always written to desktop

I'll keep this draft for a bit to get input and since it's a very recent event