### PR TITLE
build: use Node.js LTS for tooling

### DIFF
--- a/.github/workflows/sig-sec-check.yml
+++ b/.github/workflows/sig-sec-check.yml
@@ -14,6 +14,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup
         run: make setup
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
   Lint:
     runs-on: ubuntu-latest
     needs: Setup


### PR DESCRIPTION
Explicitly set a supported Node.js version which some tooling on this workflow requires.
In fact, CI currently fails on the `Spelling` step due to defaulting to Node.js 12, yet requiring Node.js 14 ([see here](https://github.com/cncf/tag-security/runs/6649092902?check_suite_focus=true)), such as:

```
+ cspell@6.0.0
added 150 packages from 65 contributors in 8.822s
From https://github.com/cncf/tag-security
 * [new branch]      main       -> main
 * [new branch]      main       -> origin/main
ApplicationError: Unsupported NodeJS version (12.22.12); >=14 is required
```