### PR TITLE
Upgrade node:12 to node:18

### DIFF
--- a/.github/workflows/sig-sec-check.yml
+++ b/.github/workflows/sig-sec-check.yml
@@ -14,9 +14,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup
         run: make setup
-      - uses: actions/setup-node@v3
-        with:
-          node-version: lts/*
   Lint:
     runs-on: ubuntu-latest
     needs: Setup

--- a/ci/spelling.sh
+++ b/ci/spelling.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 npm install -g cspell
 git fetch origin main:main
 git diff --name-only --diff-filter=AM main $HEAD | grep '\.md$' | xargs --no-run-if-empty -L1 npx cspell -c ./ci/spelling-config.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,22 +2,22 @@
 version: '2'
 services:
   setup:
-    image: node:12
+    image: node:18
     working_dir: /usr/src/app
     volumes:
       - "${PWD}:/usr/src/app"
   lint:
-    image: node:12
+    image: node:18
     working_dir: /usr/src/app
     volumes:
       - "${PWD}:/usr/src/app"
   spelling:
-    image: node:12
+    image: node:18
     working_dir: /usr/src/app
     volumes:
       - "${PWD}:/usr/src/app"
   links:
-    image: node:12
+    image: node:18
     working_dir: /usr/src/app
     volumes:
       - "${PWD}:/usr/src/app"


### PR DESCRIPTION
What: This PR upgrades node images in `docker-compose.yml` file to node:18 from node:12. It also reverts the change made in #918 

Why: `cspell` was failing earlier for all PRs. This PR attempted to fix it #918 but was unsuccessful since the node version used is defined `docker-compose.yml` file. 

