### PR TITLE
Add SecurityCon 2023 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ helping to organize!) a gathering. Create
 a [github issue](https://github.com/cncf/tag-security/issues/new) for an event
 and add to list below:
 
-- KubeCon + CloudNativeCon, Europe May 16-20 2022
+- [Cloud Native SecurityCon](https://events.linuxfoundation.org/cloudnativesecuritycon-north-america/) North America, Feb. 1-2 2023
 
 [Past events](past-events.md)
 

--- a/cloud_native_security.md
+++ b/cloud_native_security.md
@@ -1,13 +1,13 @@
-<!-- cSpell:ignore cnsecurityday -->
 
-# Cloud native security day
+# Cloud Native SecurityCon (Formerly "Cloud Native Security Day")
 
-One of the things we do as a community is Cloud Native Security day,
-designed to bring together the cloud native security community
+One of the things we do as a community is Cloud Native SecurityCon
+(previously called Security Day before it was expanded to cover two days).
+It is designed to bring together the cloud native security community
 together to discuss and share current challenges and solutions
 in cloud native security to get together in a vendor neutral space.
 
-Cloud Native Security Day (#cnsecurityday) is intended to
+Cloud Native SecurityCon is intended to
 drive collaboration, discussion, and knowledge sharing of
 cloud native security accomplishments and roadblocks. Get
 connected with others that are passionate about security.
@@ -86,3 +86,19 @@ project, architecture, and enhance team awareness on security.
 - October 12, 2021
 - Planning the event =>
   [Issue#667](https://github.com/cncf/tag-security/issues/667)
+
+### 2022
+
+[Cloud Native SecurityCon Europe](https://events.linuxfoundation.org/cloud-native-securitycon-europe/)
+
+- Valencia, Spain
+- May 16-17, 2022
+- Planning the event =>
+  [Issue#811](https://github.com/cncf/tag-security/issues/811)
+
+[Cloud Native SecurityCon North America](https://events.linuxfoundation.org/cloud-native-securitycon-north-america/)
+
+- Detroit, Michigan
+- October 24-25, 2022
+- Planning the event =>
+  [Issue#939](https://github.com/cncf/tag-security/issues/939)

--- a/past-events.md
+++ b/past-events.md
@@ -1,11 +1,11 @@
 # Past Events
 
-<!— cSpell:ignore raycolline —>
-<!— cSpell:ignore tsandall —>
-<!— cSpell:ignore timothyhinrichs —>
-<!— cSpell:ignore sreetummidi —>
+<!-- cSpell:ignore raycolline -->
+<!-- cSpell:ignore tsandall -->
+<!-- cSpell:ignore timothyhinrichs -->
+<!-- cSpell:ignore sreetummidi -->
 
-A list of past KubeCon/Cloud Native Security Day events an be found [here](cloud_native_security.md)
+A list of past KubeCon/Cloud Native SecurityCon events an be found [here](cloud_native_security.md)
 
 ## DockerCon, San Francisco, CA, Apr 30 - May 2, 2019
 


### PR DESCRIPTION
The README.md file contains a list of upcoming events, and it's quite out of date. It currently shows KubeCon Europe as happening in the future and doesn't list KubeCon 2022 (which is basically over) or SecurityCon 2023. This PR updates this to list only SecurityCon 2023 since that's the only one that's currently in the future. It also adds KubeCon EU and NA 2022 to the list of past events and updates the language around Cloud Native SecurityCon.

Fixes #998