### PR TITLE
Cspell suggestions

### DIFF
--- a/CONTRIBUTING/first-time-contributions.md
+++ b/CONTRIBUTING/first-time-contributions.md
@@ -35,7 +35,7 @@ you to go through the below resources
 for your understanding:
 
 - [How to submit contributions](https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution)
-- [Collaborating with pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests)
+- [Collaborating with pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests)
 
 Our PR also follows a particular writing
 style. Checkout the [style guide](https://github.com/cncf/tag-security/blob/main/CONTRIBUTING/writing-style.md).
@@ -54,10 +54,7 @@ You can also reach out on our slack [#tag-security-governance](https://cloud-nat
 ### You can reach out to our members
 
 Our members list can be found
-[here](https://github.com/cncf/tag-security#members).
-
-## After PR merge
-
-Once you have successfully get your
-first PR merged, you can add your name
-to our Members section in [README.md](https://github.com/cncf/tag-security#members).
+[here](https://github.com/cncf/tag-security#members). It contains only chairs
+and technical leads. To see a list of all contributors, see the
+[Insights](https://github.com/cncf/tag-security/graphs/contributors) tab
+on GitHub.

--- a/ci/link-config.json
+++ b/ci/link-config.json
@@ -9,5 +9,13 @@
     ],
     "retryCount": 3,
     "retryOn429": true,
-    "timeout": "20s"
+    "timeout": "20s",
+    "httpHeaders": [
+      {
+        "urls": ["https://docs.github.com/"],
+        "headers": {
+          "Accept-Encoding": "zstd, br, gzip, deflate"
+        }
+      }
+    ]
 }

--- a/ci/spelling.sh
+++ b/ci/spelling.sh
@@ -1,4 +1,27 @@
 #!/usr/bin/env bash
+
+function spellcheck () {
+    git diff --name-only --diff-filter=AM main $HEAD | grep '\.md$' | xargs --no-run-if-empty -L1 npx cspell --show-suggestions -c ./ci/spelling-config.json
+}
+
+function printhelp () {
+    echo
+    echo "Spelling errors detected in markdown files (see above output for details)."
+    echo "If the errors are names, external links, or unusual but accurate technical words,"
+    echo "then you should create an inline comment like:"
+    echo "<!-- cSpell:ignore someword someotherword -->"
+    echo "Of course, you should only include non-dictionary words that are correctly spelled!"
+    echo
+    echo "If the error happens because of a common technical term or proper name that is likely"
+    echo "to appear many times, then please edit \"ci/spelling-config.json\" and add it to the"
+    echo "\"words\" list."
+    echo
+
+    return 1
+}
+
+
 npm install -g cspell
 git fetch origin main:main
-git diff --name-only --diff-filter=AM main $HEAD | grep '\.md$' | xargs --no-run-if-empty -L1 npx cspell --show-suggestions -c ./ci/spelling-config.json
+# Print help if spellcheck fails
+spellcheck || printhelp


### PR DESCRIPTION
Provide suggested fix for cSpell errors. Resolves #724. Thank you to @ultrasaurus for the help text which I only modified slightly.

Note: #1001 should be merged before this.

Example output when adding a fake word to a markdown file and running `make spelling`:

```
1/1 ./CONTRIBUTING/README.md 588.82ms X
/usr/src/app/CONTRIBUTING/README.md:9:1 - Unknown word (testsett) Suggestions: [testnets, testnet, testiest, tested, testee]
CSpell: Files checked: 1, Issues found: 1 in 1 files

Spelling errors detected in markdown files (see above output for details).
If the errors are names, external links, or unusual but accurate technical words,
then you should create an inline comment like:
<!-- cSpell:ignore someword someotherword -->
Of course, you should only include non-dictionary words that are correctly spelled!

If the error happens because of a common technical term or proper name that is likely
to appear many times, then please edit "ci/spelling-config.json" and add it to the
list of "words".

make: *** [spelling] Error 1
```