### PR TITLE
Add guidance for PR collaboration

### DIFF
--- a/governance/github.md
+++ b/governance/github.md
@@ -49,7 +49,8 @@ requirements:
 To maintain the main branch in a feasible way, all Pull Requests shall come
 from repositories forked from tag-security. A unique branch name
 should be assigned to identify what will be changed in the forked
-repository. If the PR is resolving an issue, please include the issue number in the branch name or mention it in the commit message.
+repository. If the PR is resolving an issue, please include the issue number
+in the branch name or mention it in the commit message.
 After being merged the branch will be deleted.
 Future contributions shall be in a newly created branch.
 This way we can keep the repository clean and allow faster acceptance, as

--- a/governance/github.md
+++ b/governance/github.md
@@ -64,3 +64,4 @@ another member and then merged, provided that:
 
 - There have been attempts to reach out to the submitter without success, and
 - The PR has opted in to "Allow edits by maintainers"
+- The submitter has signed off on the commit

--- a/governance/github.md
+++ b/governance/github.md
@@ -44,13 +44,23 @@ requirements:
 
 ## Housekeeping
 
-To maintain the main branch in a feasible way the Pull Requests shall come
-from forked repositories from tag-security. After which an unique name
-should be assigned to identify what will be changed in the forked
-repository by utilizing branches.
+### Main branch
 
+To maintain the main branch in a feasible way, all Pull Requests shall come
+from repositories forked from tag-security. A unique branch name
+should be assigned to identify what will be changed in the forked
+repository.
 After being merged the branch will be deleted.
-Next contributions shall be in another fresh branch.
-This way we keep the repository clean and allows a faster acceptance as
-it's clear what exactly is addressed. This highly limits the amount of
-branches and stops having branches around for longer then needed.
+Future contributions shall be in a newly created branch.
+This way we can keep the repository clean and allow faster acceptance, as
+it's clear what exactly is addressed. This also keeps the number of branches
+low and prevents proliferation of stale branches.
+
+### Collaboration on pull requests
+
+Sometimes someone may submit a pull request and then be unavailable or unreachable
+to respond to change requests. In that case, the pull request may be modified by
+another member and then merged, provided that:
+
+- There have been attempts to reach out to the submitter without success, and
+- The PR has opted in to "Allow edits by maintainers"

--- a/governance/github.md
+++ b/governance/github.md
@@ -49,7 +49,7 @@ requirements:
 To maintain the main branch in a feasible way, all Pull Requests shall come
 from repositories forked from tag-security. A unique branch name
 should be assigned to identify what will be changed in the forked
-repository.
+repository. If the PR is resolving an issue, please include the issue number in the branch name or mention it in the commit message.
 After being merged the branch will be deleted.
 Future contributions shall be in a newly created branch.
 This way we can keep the repository clean and allow faster acceptance, as


### PR DESCRIPTION
- Adds a section to the github.md governance document for handling of PRs where the submitter has not been responsive to fixing requested changes.
- Also improves the grammar and language of the section that deals with branching.

See discussion in Slack (#tag-security channel). CC @TheFoxAtWork 

Signed-off-by: Shlomo Heigh <shlomo.heigh@cyberark.com>