### PR TITLE
Add initial post about security village

### DIFF
--- a/website/content/blog/security-village-eu-2023.md
+++ b/website/content/blog/security-village-eu-2023.md
@@ -1,0 +1,11 @@
+---
+title:  Security Village at KubeCon EU
+date:   2023-04-10 12:00:00 +0000
+author: Marina Moore
+---
+
+Are you disappointed there won’t be a 0-day event for Security? Don’t be! Instead, come check out the new Security Village located inside KubeCon EU throughout the conference. The Security Village will be a dedicated space for attendees to learn, share, and collaborate about the latest security practices and tools in the Kubernetes and cloud-native ecosystem. The village will feature a [series of talks](https://kccnceu2023.sched.com/type/Security+%2B+Identity/TAG+Security+Recommended), open spaces for security-related discussions, and a daily afternoon unconference. Discover a range of security-related topics, from securing software supply chains to implementing zero-trust security, managing security for cloud-native infrastructure and applications, or building a security-first culture. Each morning you can come to the village to submit topics for that afternoon’s unconference session. Industry experts, practitioners, and YOU will be able to share experiences and insights. Help us make the Security Village an inclusive and engaging destination for anyone interested in securing their cloud-native journey.
+
+## Unconference Schedule
+
+If you are at the conference, submit topics you would like to participate in each morning via our [Google form](https://docs.google.com/forms/d/e/1FAIpQLSezTTuwRLEwxkqkQls_SxJaZNu4fKXp_kstoZUeF1jisVfeCg/viewform?usp=sf_link). At lunchtime, we will list a schedule of topics here.


### PR DESCRIPTION
Add a post about the security village with a link to the unconference signup.

This page will be used during the event to list the unconference schedule.