### PR TITLE
Add repojacking example from 2021.

### DIFF
--- a/supply-chain-security/compromises/2021/repojacking.md
+++ b/supply-chain-security/compromises/2021/repojacking.md
@@ -1,0 +1,40 @@
+# Repojacking exposed private repositories through supply-chain compromise
+
+White hat researchers reported repository confusion attacks ("repojacking") to
+at least 35 public companies. By creating packages in public package
+repositories with the same name as internal packages (and, in some cases, larger
+version numbers than the internal package), build systems within the targeted
+companies would download the malicious packages from the internet, running
+arbitrary package-installation code during the build process.
+
+## Impact
+
+According to the author, reporting these issues to the affected companies
+yielded at least $130,000 in bug bounties (Shopify: $30k, Apple: $30k, PayPal:
+$30k, Microsoft: $40k), with additional companies named including Netflix, Yelp,
+and Uber.
+
+## Remediation
+
+The remediation steps depended on the package manager in question; additionally,
+some configurations of software repository software such as JFrog Artifactory
+were also implicated in this confusion between public and local libraries.
+Remediation was was performed on a per-repository or per-build basis within
+individual organizations.
+
+In most package managers, it was also possible to change package configuration
+flags (e.g. `--index-url` rather than `--extra-index-url` for `pip install`),
+but it's not clear that this applied to all package managers.
+
+## Type of Compromise
+
+This was caused by configuration of the package manager, and therefore is
+closest to the "Negligence" root cause, though the actual misconfiguration may
+have occurred in administrators of the build system or or build tooling, and
+could also be considered "Dev Tooling".
+
+## References
+
+1. Dependency Confusion: How I Hacked Into Apple, Microsoft, and Dozens of Other
+   Companies,
+   `<https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610>`

--- a/supply-chain-security/compromises/README.md
+++ b/supply-chain-security/compromises/README.md
@@ -48,6 +48,7 @@ of compromise needs added, please include that as well.
 | [PHP self-hosted git server](2021/php.md) | 2021 | Dev Tooling | [1](https://news-web.php.net/php.internals/113838) |
 | [Homebrew](2021/homebrew.md) | 2021 | Dev Tooling | [1](https://brew.sh/2021/04/21/security-incident-disclosure/), [2](https://hackerone.com/reports/1167608) |  |
 | [Codecov](2021/codecov.md) | 2021 | Source Code | [1](https://about.codecov.io/security-update/) |  |
+| [Repojacking exposed private repositories through supply-chain compromise](2021/repojacking.md) | 2021 | Negligence | [1](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610) |
 | [VSCode GitHub](2021/vscode.md) | 2021 | Dev Tooling | [1](https://www.bleepingcomputer.com/news/security/heres-how-a-researcher-broke-into-microsoft-vs-codes-github/) |  |
 | [SUNBURST/SUNSPOT/Solarigate](2020/solarwinds.md) | 2020 | Publishing Infrastructure | [1](https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html), [2](https://msrc-blog.microsoft.com/2020/12/13/customer-guidance-on-recent-nation-state-cyber-attacks/), [3](https://www.crowdstrike.com/blog/sunspot-malware-technical-analysis/) |  |
 | [The Great Suspender](2020/thegreatsuspender.md) | 2020 | Malicious Maintainer | [1](https://github.com/greatsuspender/thegreatsuspender/issues/1263),[2](https://lifehacker.com/ditch-the-great-suspender-before-it-becomes-a-security-1845989664) |


### PR DESCRIPTION
I was going through the catalog of supply chain compromises, and noticed that a novel (to me) publication from 2021 wasn't included.