### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Group meeting times are listed below:
 
 - US and Western Hemisphere:   Weekly on Wednesdays at 10:00am UTC-7 (see your timezone
   [here](https://time.is/1000_today_in_PT?CNCF_Security_TAG_US_Meeting))
-- EMEA: Bi-weekly on Wednesdays at 01:00pm London (see your timezone
+- EMEA and Eastern Hemisphere: Bi-weekly on Wednesdays at 01:00pm London (see your timezone
   [here](https://time.is/1300_today_in_London?CNCF_Security_TAG_EMEA_Meeting))
 
 [Meeting minutes and agenda](https://docs.google.com/document/d/170y5biX9k95hYRwprITprG6Mc9xD5glVn-4mB2Jmi2g/)
@@ -100,7 +100,7 @@ US and Western Hemisphere Weekly Meeting Link:
 [zoom.us/my/cncftagsecurity](https://zoom.us/j/99809474566) The meeting requires signing in to Zoom to join.
 Meeting ID: 998 0947 4566
 
-Eastern Hemisphere Bi-weekly meeting:
+EMEA and Eastern Hemisphere Bi-weekly meeting:
 
 Meeting Link: zoom.us/my/cncftagsecurity (Password: 77777)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ and posting to the channels.
 
 Group meeting times are listed below:
 
-- US:   Weekly on Wednesdays at 10:00am UTC-7 (see your timezone
+- US and Western Hemisphere:   Weekly on Wednesdays at 10:00am UTC-7 (see your timezone
   [here](https://time.is/1000_today_in_PT?CNCF_Security_TAG_US_Meeting))
 - EMEA: Bi-weekly on Wednesdays at 01:00pm London (see your timezone
   [here](https://time.is/1300_today_in_London?CNCF_Security_TAG_EMEA_Meeting))
@@ -96,9 +96,13 @@ added to the Agenda on our [process](governance/process.md#getting-on-the-agenda
 ### Zoom Meeting Details
 
 <!-- cSpell:ignore cncftagsecurity -->
-Meeting Link:
-[zoom.us/my/cncftagsecurity](https://zoom.us/j/7375677271?pwd=VkxmTjJ6TDVHK29Qb2tQakE4SitWZz09)
-(Password: 77777)
+US and Western Hemisphere Weekly Meeting Link:
+[zoom.us/my/cncftagsecurity](https://zoom.us/j/99809474566) The meeting requires signing in to Zoom to join.
+Meeting ID: 998 0947 4566
+
+Eastern Hemisphere Bi-weekly meeting:
+
+Meeting Link: zoom.us/my/cncftagsecurity (Password: 77777)
 
 Meeting ID: 737 567 7271
 


### PR DESCRIPTION
Update meeting ID. 

The motivation for this change, automated livestream and upload to youtube broke a while back with changes to how livestream is configured. It no longer allows use of streaming using personal room id.

Also retitled US and EMEA to US and Western Hemisphere and Eastern Hemisphere for inclusivity.