### PR TITLE
Static update to the TAG Website landing page with contents from TAG README.md

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -15,36 +15,234 @@ toc_hide: true
 </div>
 
 
-The TAG produces guidance for and gathers feedback from cloud app users and
-developers and provides guidance and coordination to CNCF projects in the TAG's
-technical domains.
+# CNCF Security Technical Advisory Group
 
-- [TAG Charter](https://github.com/cncf/toc/blob/main/tags/security.md)
-- [Community events](https://community.cncf.io/tag-app-delivery/)
-- Slack channel: [#tag-security](https://cloud-native.slack.com/archives/CDJ7MLT8S)
-    - [Invite yourself to the CNCF Slack](https://slack.cncf.io/)
-- [Mailing list](https://lists.cncf.io/g/cncf-tag-security/topics)
+<!-- cspell:disable -->
+<!-- markdownlint-disable-next-line MD033 MD013 -->
+<img src="design/logo/cloud-native-security-horizontal-darkmodesafe.svg" alt="Cloud Native Security logo" />
+<!-- cSpell:enable -->
 
-<p class="mt-5"><img src="/images/man-using-laptop.jpg" alt="Man working on computer"></p>
+## Quick links
+
+- [Meeting Information](#meeting-times)
+- [Slack Information](#communications)
+- [New Members](#new-members)
+- [Members](#members)
+
+## Objective
+
+The CNCF Security Technical Advisory Group facilitates collaboration to discover and produce resources that enable
+secure access, policy control, and safety for operators, administrators,
+developers, and end-users across the cloud native ecosystem.
+
+## Background
+
+Cloud Native describes the building, deploying, and operating of modern applications in cloud computing environments, typically using open source. This complex ecosystem composed of different open source projects presents an increasingly complicated technology risk landscape. While there are several projects in the cloud native ecosystem that address trust, safety, and security in the dynamic interplay between the different layers of infrastructure and application services, the technological shift demands application and information security be rethought through the lens of developer experience as close to applying software engineering to design for security considerations in the effort to safeguard an integrated cloud native ecosystem as a whole.
 
 
-## Meetings
+## Vision
 
-1st and 3rd Wednesday of each month at 16:00 UTC ([convert to your local
-time](https://dateful.com/convert/utc?t=16)).
+We believe in a future where the probability and impact of attacks, breaches, and compromises are significantly reduced. Where the most common risks of today are not just mitigated but made implausible. We believe developers and operators can be empowered to understand better and be reassured by the posture of the systems they build and run through the informed use of cloud technologies with clear
+understanding of responsibility and risks and the unlocked ability to validate that their architectural intent meets compliance and regulatory objectives.
 
-Meetings are listed on the [main CNCF calendar](https://www.cncf.io/calendar/)
-as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-delivery/).
+There is a growing ecosystem of tools that promises to unlock developer productivity and operational efficiency. We strive to fulfill the human side of the sociotechnical equation to acceleration and attain that promise including:
 
-* [Agenda and Notes](https://docs.google.com/document/d/1OykvqvhSG4AxEdmDMXilrupsX2n1qCSJUWwTc3I7AOs/edit#)
-* [Zoom Meeting](https://zoom.us/j/7276783015) (Passcode: 77777)
-* [Recordings of previous meetings](https://www.youtube.com/playlist?list=PLj6h78yzYM2OHd1Ht3jiZuucWzvouAAci)
+1. Consumable system security architectures that account for the ever
+   growing heterogeneity of systems and provides a framework to protect
+   resources and data while servicing their users.
+2. Common lexicon and open source libraries that make it easy for developers
+   to create and deploy apps that meet system security requirements.
+3. Common libraries and protocols that enable people to reason about the
+   security of the system, such as auditing and explainability features.
 
-## Leads
+## Publications
 
-- [Alois Reitbauer](https://github.com/AloisReitbauer) (Chair)
-- [Jennifer Strejevitch](https://github.com/jenniferstrej) (Chair)
-- [Hongchao Deng](https://github.com/hongchaodeng) (Chair)
-- [Alex Jones](https://github.com/alexsjones) (TL)
-- [Thomas Schuetz](https://github.com/thschue) (TL)
-- [Josh Gavant](https://github.com/joshgav) (TL)
+TAG Security has published several resources for the community, which can be
+found in the [publications](PUBLICATIONS.md) document.
+
+## Governance
+
+[Security TAG charter](governance/charter.md) outlines the scope of our group
+activities, as part of our [governance process](governance) which details how we
+work.
+
+## Communications
+
+Anyone is welcome to join our open discussions of Security TAG projects and share news
+related to the group's mission and charter. Much of the work of the group
+happens outside of Security TAG meetings and we encourage project teams to share
+progress updates or post questions in these channels:
+
+Group communication:
+
+- [Email list](https://lists.cncf.io/g/cncf-tag-security)
+- [CNCF Slack](https://slack.cncf.io/) #tag-security channel
+
+Leadership:
+
+- To reach the leadership team (chairs & tech leads), email
+  cncf-tag-security-leads@lists.cncf.io
+- To reach the chairs, email cncf-tag-security-chairs@lists.cncf.io
+
+### Slack governance
+
+Refer to the [slack governance document](slack.md) for details on slack channels
+and posting to the channels.
+
+## Meeting times
+
+Group meeting times are listed below:
+
+- US:   Weekly on Wednesdays at 10 am UTC-7 (see your timezone
+  [here](https://time.is/1000_today_in_PT?CNCF_Security_TAG_US_Meeting))
+- EMEA: Bi-weekly on Wednesdays at 1 pm UTC+0 (UTC+1 while observing daylight savings) (see your timezone
+  [here](https://time.is/UTC?CNCF_Security_TAG_EMEA_Meeting))
+
+[Meeting minutes and agenda](https://docs.google.com/document/d/170y5biX9k95hYRwprITprG6Mc9xD5glVn-4mB2Jmi2g/)
+
+### Calendar
+
+- Here is a [TAG-Security curated calendar](https://calendar.google.com/calendar/u/0?cid=MGI4dTVlbDh0YTRzOTN0MmNtNzJ0dXZoaGtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
+with the main meetings and working groups.
+- See the [CNCF Calendar](https://www.cncf.io/calendar/) for a list of all CNCF calendar
+invites.
+
+Got something to bring up or share? Review how to get a topic or presentation
+added to the Agenda on our [process](governance/process.md#getting-on-the-agenda) page.
+
+### Zoom Meeting Details
+
+#### [North America] CNCF TAG-Security Weekly Meeting
+
+https://zoom.us/j/99809474566
+
+Meeting ID: 998 0947 4566
+
+#### [EMEA] CNCF TAG-Security Weekly Meeting
+
+https://zoom.us/j/99917523142
+
+Meeting ID: 999 1752 3142
+
+## Gatherings
+
+Please let us know if you are going and if you are interested in attending (or
+helping to organize!) a gathering. Create
+a [github issue](https://github.com/cncf/tag-security/issues/new) for an event
+and add to list below:
+
+<!-- markdownlint-disable-next-line MD013 -->
+- [Cloud Native SecurityCon 24](https://events.linuxfoundation.org/cloudnativesecuritycon-north-america/) June 26-27, 2024 in Seattle, Washington
+
+[Past events](past-events.md)
+
+## New members
+
+If you are new to the group, we encourage you to check out
+our [New Members Page](NEW-MEMBERS.md)
+
+## Related groups
+
+There are several groups that are affiliated to or do work and cover topics
+relevant to the work of Security TAG. These can be
+seen [here](governance/related-groups/)
+
+## History
+
+- TAG-Security - renamed Security TAG ([TOC Issue 549](https://github.com/cncf/toc/issues/549))
+- SAFE WG - renamed to CNCF Security TAG
+- [(Proposed) CNCF Policy Working Group](/policy-wg-merging.md) - Merged into
+  SAFE WG
+
+## Members
+
+<!-- cSpell:disable -->
+
+### Security TAG Chairs
+
+- Aradhana Chetal ([@achetal01](https://github.com/achetal01)), TIAA [Chair term: 6/3/2021 - 9/3/2023]
+- Andrew Martin ([@sublimino](https://github.com/sublimino)), ControlPlane [Chair term: 3/17/2022 - 3/17/2024]
+- Pushkar Joglekar ([@PushkarJ](https://github.com/PushkarJ)), Independent [Chair term: 6/3/2023 - 6/3/2025]
+
+### Tech Leads
+
+- Justin Cappos ([@JustinCappos](https://github.com/JustinCappos)), New York
+  University
+- Ash Narkar ([@ashutosh-narkar](https://github.com/ashutosh-narkar)), Styra
+- Andres Vega ([@anvega](https://github.com/anvega))
+- Ragashree Shekar ([@ragashreeshekar](https://github.com/ragashreeshekar)), Independent
+- Michael Lieberman ([@mlieberman85](https://github.com/mlieberman85)), Kusari
+- Marina Moore ([@mnm678](https://github.com/mnm678)), NYU
+
+### Security TAG Chair Emeriti
+
+- Dan Shaw ([@dshaw](https://github.com/dshaw)),
+  PayPal [Chair term: 6/3/2019 - 9/3/2020]
+- Sarah Allen ([@ultrasaurus](https://github.com/ultrasaurus)), [Chair term:
+  6/3/2019 - 6/3/2021]
+- Jeyappragash JJ ([@pragashj](https://github.com/pragashj)),
+  Tetrate.io [Chair term: 6/3/2019 - 6/3/2021]
+- Emily Fox ([@TheFoxAtWork](https://github.com/TheFoxAtWork)),
+  Apple [Chair term: 9/28/2020 - 2/4/2022]
+- Brandon Lum ([@lumjjb](https://github.com/lumjjb)), Google [Chair term:
+  6/3/2021 - 6/3/2023]
+
+### On-going projects
+
+#### Policy team
+
+Policy is an essential component of a secure system.
+
+[Bi-weekly meetings](https://docs.google.com/document/d/1ihFfEfgViKlUMbY2NKxaJzBkgHh-Phk5hqKTzK-NEEs/edit?usp=sharing)
+at 3:00 PM PT focus on policy concerns and initiatives.
+
+Co-leads
+
+- TBD
+
+Co-chair representative: @achetal01
+
+#### Security reviews
+
+[Security reviews](./assessments) are a collaborative process for the benefit of
+cloud native projects and prospective users by creating a consistent overview of
+the project and its risk profile.
+
+Facilitator: Justin Cappos ([@JustinCappos](https://github.com/JustinCappos)),
+New York University
+
+Facilitator: Andres Vega ([@anvega](https://github.com/anvega)), ControlPlane
+
+Co-chair representatives: @sublimino @PushkarJ
+
+#### Software Supply Chain Security
+
+Software Supply Chain attacks have come to the wider community's attention
+following recent high-profile attack, but have been an ongoing threat for a long
+time. With the ever growing importance of free and open source software,
+software [supply chain security](./supply-chain-security) is crucial,
+particularly in cloud native environments where everything is software-defined.
+
+Weekly meetings at 8:00 AM PT (50 min) (see your
+timezone [here](https://time.is/0800_today_in_PT?CNCF_Security_TAG_Supply_Chain_WG_Meeting))
+See [CNCF calendar](https://www.cncf.io/calendar/) for invite.
+
+Facilitator for current deliverables is listed on
+the [issue](https://github.com/cncf/tag-security/issues/679)
+
+## Additional information
+
+### CNCF Security TAG reviews
+
+As part of
+the [CNCF project proposal process](https://github.com/cncf/toc/blob/main/process/project_proposals.md)
+projects should create a
+new [security review issue](https://github.com/cncf/tag-security/issues/new?assignees=&labels=assessment&template=security-assessment.md&title=%5BAssessment%5D+Project+Name)
+with a
+[self-assessment](https://github.com/cncf/tag-security/blob/main/assessments/guide/self-assessment.md)
+.
+
+### Past events and meetings
+
+For more details on past events and meetings, please see
+our [past events page](past-events.md)

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -15,11 +15,8 @@ toc_hide: true
 </div>
 
 
-# CNCF Security Technical Advisory Group
-
 <!-- cspell:disable -->
 <!-- markdownlint-disable-next-line MD033 MD013 -->
-<img src="design/logo/cloud-native-security-horizontal-darkmodesafe.svg" alt="Cloud Native Security logo" />
 <!-- cSpell:enable -->
 
 ## Quick links


### PR DESCRIPTION
Per. CNCF service ticket https://cncfservicedesk.atlassian.net/servicedesk/customer/portal/1/CNCFSD-1988, TAG website template is a starting point and we maintain it henceforth. As discussed with the Chairs + TLs updating our website landing page with contents from our TAG README.md. 

This is a static update to address https://github.com/cncf/tag-security/issues/1116, however we might need to brainstorm approaches to ensure the README.md is mirrored in the website index for long term sustenance efforts. 
