### PR TITLE
Remove actions and update self-assesment

### DIFF
--- a/assessments/projects/jaeger/actions.md
+++ b/assessments/projects/jaeger/actions.md
@@ -1,4 +1,0 @@
-### Action Items.
-
-Develop addition to Jaeger Query’s Jaeger UI to sanitize keys of objects. Currently json-markup is used and does not sanitize keys leaving the KeyValuesTable vulnerable to XSS.
-Related Security Advisory Link: https://github.com/jaegertracing/jaeger/security/advisories/GHSA-2w8w-qhg4-f78j

--- a/assessments/projects/jaeger/self-assessment.md
+++ b/assessments/projects/jaeger/self-assessment.md
@@ -1,6 +1,6 @@
 # Jaeger Self-assessment
 
-This assessment was created by community members as part of the [Security Pals](https://github.com/cncf/tag-security/issues/1102) process and is currently pending changes from the maintainer team.
+This assessment was created by community members as part of the [Security Pals](https://github.com/cncf/tag-security/issues/1102) process. The Jaeger team thanks them for the contribution!
 
 ## Table of contents
 

--- a/assessments/projects/jaeger/self-assessment.md
+++ b/assessments/projects/jaeger/self-assessment.md
@@ -23,7 +23,7 @@ This assessment was created by community members as part of the [Security Pals](
 
 |   |  |
 | -- | -- |
-| Assessment Stage | Incomplete |
+| Assessment Stage | Complete |
 | **Software** | [A link to Jaeger’s repository.](https://github.com/jaegertracing/jaeger)  |
 | **Security Provider** | No, the main function of this project is to enable distributed tracing in an organization’s tech infrastructure. Security is not the primary objective.  |
 | **Languages** | <ul><li>Go</li><li>Shell</li><li>Makefile</li><li>Python</li><li>Dockerfile</li></ul> |


### PR DESCRIPTION
I have updated the self-assesment to remove the "pending changes" part of the text and thank the Security Pals folks for the contribution to the project!

I have removed the actions.md file as well since the issue flagged there was corrected in July 2023 per [this Github advisory](https://github.com/jaegertracing/jaeger/security/advisories/GHSA-2w8w-qhg4-f78j). 