### PR TITLE
ci: fix ci linter scripts

### DIFF
--- a/ci/links.sh
+++ b/ci/links.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 
+set -e
+shopt -s globstar
+
+FAILURE=0
+
+git config --global --add safe.directory /usr/src/app
 npm install -g markdown-link-check
 git fetch origin main:main
 # To run this on the entire repo, replace the following command with `$(find ./ -type f | grep .md)`
-for file_name in $(git diff --name-only $HEAD main); do
-  if [[ $file_name == *".md" ]]; then
-    npx markdown-link-check --config ./ci/link-config.json --progress --verbose "$file_name"
-  fi
+for file_name in $(git diff --name-only $HEAD main -- ./**/*.md); do
+  npx markdown-link-check --config ./ci/link-config.json --progress --verbose "$file_name" || FAILURE=1
 done
+
+exit $FAILURE

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 
+set -e
+shopt -s globstar
+
+FAILURE=0
+
+git config --global --add safe.directory /usr/src/app
 npm install -g markdownlint-cli
 git fetch origin main:main
 # To run this on the entire repo, replace the following command with `$(find ./ -type f | grep .md)`
-for file_name in $(git diff --name-only $HEAD main); do
-  if [[ $file_name == *".md" ]]; then
-    markdownlint -c ./ci/lint-config.json "$file_name"
-  fi
+for file_name in $(git diff --name-only $HEAD main -- ./**/*.md); do
+  markdownlint -c ./ci/lint-config.json "$file_name" || FAILURE=1
 done
+
+exit $FAILURE

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -e
+
+git config --global --add safe.directory /usr/src/app
 git fetch origin main:main
 git diff --name-only main $HEAD > modified
 echo "these files have changed"

--- a/ci/spelling.sh
+++ b/ci/spelling.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+shopt -s globstar
+
 function spellcheck () {
-    git diff --name-only --diff-filter=AM main $HEAD | grep '\.md$' | xargs --no-run-if-empty -L1 npx cspell --show-suggestions -c ./ci/spelling-config.json
+    FAILURE=0
+    git diff --name-only --diff-filter=AM main $HEAD -- ./**/*.md | \
+        xargs --no-run-if-empty -L1 npx cspell --show-suggestions -c ./ci/spelling-config.json || FAILURE=1
+    return $FAILURE
 }
 
 function printhelp () {
@@ -21,6 +27,7 @@ function printhelp () {
 }
 
 
+git config --global --add safe.directory /usr/src/app
 npm install -g cspell
 git fetch origin main:main
 # Print help if spellcheck fails


### PR DESCRIPTION
Linting scripts were failing to Git safe dirertory check, both when run via GH actions, or locally via docker-compose. To fix the scripts, few things need to be changed.

1. Add /usr/src/app to Git safe directories, so Git will run any Git commands, such as "git fetch ..." in that directory.
2. Add "set -e" so command failure will fail the script, to produce correct return code for the check.
3. Due "set -e", and the loop we are running, we need to ignore the linting command returning failure, and capture the failure to be returned later command.
4. We also need to remove the grep from the pipeline. If the commit has no matching files, it would return false error, thanks to "-o pipefail". Same can be applied to all scripts, having Git filter the wanted files, instead of having additional if clause.

Git safe directory check was introduced already in Git 2.35.2 in 2022, and the "ubuntu-latest" image used by the GH action shouldn't have taken  too long to upgrade to that or newer Git version. The old GH action logs only go back a month, and they're all showing the same. It could  be that the actions have been broken for 1.5 years. The same can bereproduced locally, as the node:18 image used by the docker-compose is also having recent enough Git.

This is tested locally to produce correct behavior for all three cases, and also when no matching files have been changed.

Fixes: #1221 