### PR TITLE
Add various supply chain incidents to the catalog

### DIFF
--- a/supply-chain-security/compromises/2003/kernel-repository.md
+++ b/supply-chain-security/compromises/2003/kernel-repository.md
@@ -1,0 +1,18 @@
+# Linux Kernel CVS Repository Hack
+
+An attacker attempted to backdoor the Linux kernel by submitting changes to a
+CVS repository mirror of the main repository.
+
+## Impact
+
+The impact of this incident was low because the CVS repository was only a mirror
+of the main BitKeeper repository. As new changes were typically not submitted to
+the CVS repository directly, the attack was quickly noticed.
+
+## Type of Compromise
+
+Source Code and Dev Tooling
+
+## References
+
+- [An attempt to backdoor the kernel](https://lwn.net/Articles/57135/)

--- a/supply-chain-security/compromises/2010/fsf-website.md
+++ b/supply-chain-security/compromises/2010/fsf-website.md
@@ -1,0 +1,16 @@
+# Free Software Foundation Website Hack
+
+The source repository for the FSF's website was hacked via a SQL injection.
+
+## Impact
+
+The attackers defaced the website. In addition, the attackers were able to
+exfiltrate user names and encrypted passwords from the affected server.
+
+## Type of Compromise
+
+Source Code
+
+## References
+
+- [Free Software Foundation's software repository hacked](https://www.computerworld.com/article/2752415/free-software-foundation-s-software-repository-hacked.html)

--- a/supply-chain-security/compromises/2012/ruby-on-rails-github.md
+++ b/supply-chain-security/compromises/2012/ruby-on-rails-github.md
@@ -1,0 +1,21 @@
+# GitHub Ruby on Rails Repository Hack
+
+The GitHub repository for the Ruby on Rails was compromised by an ethical hacker
+using a vulnerability in the GitHub API.
+
+## Impact
+
+The Rails repository had an unauthorized commit added to it. GitHub responded
+rapidly by fixing the vulnerability and the Rails maintainers removed the
+commit. GitHub also improved its responsible disclosure mechanisms to enable
+security researchers to submit issues without resorting to actually exploiting
+the vulnerability.
+
+## Type of Compromise
+
+Source Code and Dev Tooling
+
+## References
+
+- [Hacking rails/rails repo](https://homakov.blogspot.com/2012/03/how-to.html)
+- [Responsible Disclosure Policy](https://github.blog/2012-03-05-responsible-disclosure-policy/)

--- a/supply-chain-security/compromises/2021/php.md
+++ b/supply-chain-security/compromises/2021/php.md
@@ -7,6 +7,10 @@ add backdoor capabilities.
 
 ## Impact
 
+<!-- cSpell:ignore Rasmus -->
+<!-- cSpell:ignore Lerdorf -->
+<!-- cSpell:ignore Popov -->
+
 * Code changes in the form of two commits to the official and self-hosted Git
 server were made as if they were signed-off by PHP maintainers Rasmus Lerdorf
 and Nikita Popov.

--- a/supply-chain-security/compromises/2021/php.md
+++ b/supply-chain-security/compromises/2021/php.md
@@ -24,9 +24,9 @@ declared their GitHub PHP project repository as the primary source.
 
 ## Type of Compromise
 
-Source Code: Still unknown how the threat actors were able to gain access to
-the Git server, compromising the source code that powers 79.2% of all
-websites [2].
+Source Code and Dev Tooling: Still unknown how the threat actors were able to
+gain access to the Git server, compromising the source code that powers 79.2% of
+all websites [2].
 
 ## References
 

--- a/supply-chain-security/compromises/2022/auth0-source-code-leak.md
+++ b/supply-chain-security/compromises/2022/auth0-source-code-leak.md
@@ -1,0 +1,23 @@
+# Auth0 Code Repository Stolen
+
+Auth0, part of Okta, revealed that its source repository archives from 2020 and
+before were stolen.
+
+## Impact
+
+A "third-party individual" informed Okta that they possessed Auth0 source code
+from 2020 and earlier. An investigation was unable to find unauthorized access
+to Okta environments.
+
+## Type of Compromise
+
+It's not entirely clear what the type of compromise is here. It appears to be
+source code like the [Intel BIOS
+leak](/supply-chain-security/compromises/2022/intel-alder-lake-BIOS-leak.md) and
+might also involve dev tooling depending on how the attacker gained access to
+the source code.
+
+## References
+
+- [Auth0 Code Repository Archives From 2020 and Earlier](https://auth0.com/blog/auth0-code-repository-archives-from-2020-and-earlier/)
+- [Auth0 warns that some source code repos may have been stolen](https://www.bleepingcomputer.com/news/security/auth0-warns-that-some-source-code-repos-may-have-been-stolen/)

--- a/supply-chain-security/compromises/2022/okta-github-repo-leak.md
+++ b/supply-chain-security/compromises/2022/okta-github-repo-leak.md
@@ -1,0 +1,17 @@
+# Okta Source Code Theft
+
+Okta revealed its private GitHub repositories were compromised by attackers to
+exfiltrate proprietary source code.
+
+## Impact
+
+GitHub notified Okta of suspicious activity, following which the unauthorized
+access was detected. No customer data was involved in the process.
+
+## Type of Compromise
+
+Source Code and Dev Tooling
+
+## References
+
+- [Okta's source code stolen after GitHub repositories hacked](https://www.bleepingcomputer.com/news/security/oktas-source-code-stolen-after-github-repositories-hacked/)

--- a/supply-chain-security/compromises/2023/fake-dependabot.md
+++ b/supply-chain-security/compromises/2023/fake-dependabot.md
@@ -1,0 +1,24 @@
+# Fake Dependabot commits
+
+Dependabot is a bot maintained by GitHub that automatically submits pull
+requests to update project dependencies. An attacker pushed malicious commits
+impersonating Dependabot which were subsequently merged by repository
+maintainers. These commits included changes that introduced a GitHub Action
+workflow to steal repository secrets. In addition, the attackers added an
+obfuscated line to all javascript source files to steal information added to
+password fields.
+
+## Impact
+
+The attackers submitted hundreds of such commits, primarily targeting GitHub
+users in Indonesia. To directly push the commits, the attackers also stole
+repository maintainer access tokens, to allow them to bypass two factor
+authentication.
+
+## Type of Compromise
+
+Source Code
+
+## References
+
+- [Surprise: When Dependabot Contributes Malicious Code](https://checkmarx.com/blog/surprise-when-dependabot-contributes-malicious-code/)

--- a/supply-chain-security/compromises/README.md
+++ b/supply-chain-security/compromises/README.md
@@ -94,6 +94,7 @@ of compromise needs added, please include that as well.
 | [Monju Incident](2014/monju.md) | 2014    | Publishing infrastructure| [1](https://www.contextis.com/en/blog/context-threat-intelligence-the-monju-incident)
 | [APT lack of validation for source packages](2013/apt.md) | 2013 | Negligence | [1](https://lwn.net/Articles/602461/) |
 | [kernel.org compromise](2011/kernelorg.md) | 2011 | Publishing infrastructure | [1](https://lwn.net/Articles/461237/), [2](https://lwn.net/Articles/461552/) |
+| [FSF Website Hack](2010/fsf-website.md) | 2010 | Source Code | [1](https://www.computerworld.com/article/2752415/free-software-foundation-s-software-repository-hacked.html) |
 | [apache.org incident](2010/apache.md) | 2010 | Attack Chaining | [1](https://blogs.apache.org/infra/entry/apache_org_04_09_2010) |
 | [Operation Aurora](2010/aurora.md) | 2010 | Watering-hole attack | [1](https://www.wired.com/2010/03/source-code-hacks/) |
 | [ProFTPD](2010/proftpd.md) | 2010 | Publishing Infrastructure | [1](https://www.zdnet.com/article/open-source-proftpd-hacked-backdoor-planted-in-source-code/) |

--- a/supply-chain-security/compromises/README.md
+++ b/supply-chain-security/compromises/README.md
@@ -48,7 +48,7 @@ of compromise needs added, please include that as well.
 | [Compromise of npm packages coa and rc](2021/coa-rc.md) | 2021 | Malicious Maintainer | [1](https://blog.sonatype.com/npm-hijackers-at-it-again-popular-coa-and-rc-open-source-libraries-taken-over-to-spread-malware) |
 | [Compromise of ua-parser-js](2021/ua-parser-js.md) | 2021 | Malicious Maintainer | [1](https://github.com/faisalman/ua-parser-js/issues/536) |
 | [The klow / klown / okhsa incident](2021/klow-klown-okhsa.md) | 2021 | Negligence | [1](https://blog.sonatype.com/newly-found-npm-malware-mines-cryptocurrency-on-windows-linux-macos-devices) |
-| [PHP self-hosted git server](2021/php.md) | 2021 | Dev Tooling | [1](https://news-web.php.net/php.internals/113838) |
+| [PHP self-hosted git server](2021/php.md) | 2021 | Source Code <br> Dev Tooling | [1](https://news-web.php.net/php.internals/113838) |
 | [Homebrew](2021/homebrew.md) | 2021 | Dev Tooling | [1](https://brew.sh/2021/04/21/security-incident-disclosure/), [2](https://hackerone.com/reports/1167608) |  |
 | [Codecov](2021/codecov.md) | 2021 | Source Code | [1](https://about.codecov.io/security-update/) |  |
 | [Repojacking exposed private repositories through supply-chain compromise](2021/repojacking.md) | 2021 | Negligence | [1](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610) |

--- a/supply-chain-security/compromises/README.md
+++ b/supply-chain-security/compromises/README.md
@@ -30,6 +30,9 @@ of compromise needs added, please include that as well.
 <!-- cSpell:disable -->
 | Name              | Year               | Type of compromise    | Link        |
 | ----------------- | ------------------ | ------------------    | ----------- |
+| [Fake Dependabot commits](2023/fake-dependabot.md) | 2023 | Source Code | [1](https://checkmarx.com/blog/surprise-when-dependabot-contributes-malicious-code/) |
+| [Okta Source Code Theft](2022/okta-github-repo-leak.md) | 2022 | Source Code <br> Dev Tooling | [1](https://www.bleepingcomputer.com/news/security/oktas-source-code-stolen-after-github-repositories-hacked/)
+| [Auth0 Source Code Theft](2022/auth0-source-code-leak.md) | 2022 | Source Code <br> Dev Tooling | [1](https://auth0.com/blog/auth0-code-repository-archives-from-2020-and-earlier/) [2](https://www.bleepingcomputer.com/news/security/auth0-warns-that-some-source-code-repos-may-have-been-stolen/)
 | [RubyGems Package Overwrite Flaw](2022/rubygems-override.md) | 2022 | Publishing Infrastructure | [1](https://www.bleepingcomputer.com/news/security/check-your-gems-rubygems-fixes-unauthorized-package-takeover-bug/)
 | [Legitimate software update mechanism abused to deliver wiper malware](2022/fantasy.md) | 2022 | Publishing Infrastructure | [1](https://www.welivesecurity.com/2022/12/07/fantasy-new-agrius-wiper-supply-chain-attack/)|
 | [Docker Hub malicious containers](2022/docker-hub-malicious-containers.md) | 2022 | Publishing Infrastructure | [1](https://www.bleepingcomputer.com/news/security/docker-hub-repositories-hide-over-1-650-malicious-containers/)

--- a/supply-chain-security/compromises/README.md
+++ b/supply-chain-security/compromises/README.md
@@ -33,13 +33,13 @@ of compromise needs added, please include that as well.
 | [Fake Dependabot commits](2023/fake-dependabot.md) | 2023 | Source Code | [1](https://checkmarx.com/blog/surprise-when-dependabot-contributes-malicious-code/) |
 | [Okta Source Code Theft](2022/okta-github-repo-leak.md) | 2022 | Source Code <br> Dev Tooling | [1](https://www.bleepingcomputer.com/news/security/oktas-source-code-stolen-after-github-repositories-hacked/) |
 | [Auth0 Source Code Theft](2022/auth0-source-code-leak.md) | 2022 | Source Code <br> Dev Tooling | [1](https://auth0.com/blog/auth0-code-repository-archives-from-2020-and-earlier/) [2](https://www.bleepingcomputer.com/news/security/auth0-warns-that-some-source-code-repos-may-have-been-stolen/) |
-| [RubyGems Package Overwrite Flaw](2022/rubygems-override.md) | 2022 | Publishing Infrastructure | [1](https://www.bleepingcomputer.com/news/security/check-your-gems-rubygems-fixes-unauthorized-package-takeover-bug/)
+| [RubyGems Package Overwrite Flaw](2022/ruby-override.md) | 2022 | Publishing Infrastructure | [1](https://www.bleepingcomputer.com/news/security/check-your-gems-rubygems-fixes-unauthorized-package-takeover-bug/) |
 | [Legitimate software update mechanism abused to deliver wiper malware](2022/fantasy.md) | 2022 | Publishing Infrastructure | [1](https://www.welivesecurity.com/2022/12/07/fantasy-new-agrius-wiper-supply-chain-attack/)|
-| [Docker Hub malicious containers](2022/docker-hub-malicious-containers.md) | 2022 | Publishing Infrastructure | [1](https://www.bleepingcomputer.com/news/security/docker-hub-repositories-hide-over-1-650-malicious-containers/)
-| [Chat100 live chat trojan](2022/Comm100-live-chat-trojan.md) | 2022 | Publishing Infrastructure | [1](https://www.securityweek.com/supply-chain-attack-targets-customer-engagement-firm-comm100)
-| [Dropbox GitHub compromise](2022/dropbox-github-account-breach.md) | 2022 | Attack Chaining | [1](https://www.bleepingcomputer.com/news/security/dropbox-discloses-breach-after-hacker-stole-130-github-repositories/)
-| [Intel Alder Lake BIOS leak](2022/intel-alder-lake-BIOS-leak.md) | 2022 | Source Code | [1](https://www.tomshardware.com/news/intel-confirms-6gb-alder-lake-bios-source-code-leak-new-details-emerge)
-| [PEAR PHP Package Manager compromise](2022/php-pear-compromise.md) | 2022 | Dev Tooling | [1](https://blog.sonarsource.com/php-supply-chain-attack-on-pear/)
+| [Docker Hub malicious containers](2022/docker-hub-malicious-containers.md) | 2022 | Publishing Infrastructure | [1](https://www.bleepingcomputer.com/news/security/docker-hub-repositories-hide-over-1-650-malicious-containers/) |
+| [Chat100 live chat trojan](2022/Comm100-live-chat-trojan.md) | 2022 | Publishing Infrastructure | [1](https://www.securityweek.com/supply-chain-attack-targets-customer-engagement-firm-comm100) |
+| [Dropbox GitHub compromise](2022/dropbox-github-account-breach.md) | 2022 | Attack Chaining | [1](https://www.bleepingcomputer.com/news/security/dropbox-discloses-breach-after-hacker-stole-130-github-repositories/) |
+| [Intel Alder Lake BIOS leak](2022/intel-alder-lake-BIOS-leak.md) | 2022 | Source Code | [1](https://www.tomshardware.com/news/intel-confirms-6gb-alder-lake-bios-source-code-leak-new-details-emerge) |
+| [PEAR PHP Package Manager compromise](2022/php-pear-compromise.md) | 2022 | Dev Tooling | [1](https://blog.sonarsource.com/php-supply-chain-attack-on-pear/) |
 | [npm Library ‘node-ipc’ Sabotaged with npm Library ‘peacenotwar’ in Protest by their Maintainer](2022/node-ipc-peacenotwar.md) | 2022 | Malicious Maintainer | [1](https://snyk.io/blog/peacenotwar-malicious-npm-node-ipc-package-vulnerability/)|
 | [npm Libraries ‘colors’ and ‘faker’ Sabotaged in Protest by their Maintainer](2022/js-faker-colors.md) | 2022 | Malicious Maintainer | [1](https://www.revenera.com/blog/software-composition-analysis/the-story-behind-colors-js-and-faker-js/)|
 | [GCP Golang Buildpacks Old Compiler Injection](2022/golang-buildpacks-compiler.md) | 2022 | Source Code | [1](https://zt.dev/posts/gcp-buildpacks-old-compiler/)|
@@ -49,11 +49,11 @@ of compromise needs added, please include that as well.
 | [Compromise of ua-parser-js](2021/ua-parser-js.md) | 2021 | Malicious Maintainer | [1](https://github.com/faisalman/ua-parser-js/issues/536) |
 | [The klow / klown / okhsa incident](2021/klow-klown-okhsa.md) | 2021 | Negligence | [1](https://blog.sonatype.com/newly-found-npm-malware-mines-cryptocurrency-on-windows-linux-macos-devices) |
 | [PHP self-hosted git server](2021/php.md) | 2021 | Source Code <br> Dev Tooling | [1](https://news-web.php.net/php.internals/113838) |
-| [Homebrew](2021/homebrew.md) | 2021 | Dev Tooling | [1](https://brew.sh/2021/04/21/security-incident-disclosure/), [2](https://hackerone.com/reports/1167608) |  |
-| [Codecov](2021/codecov.md) | 2021 | Source Code | [1](https://about.codecov.io/security-update/) |  |
+| [Homebrew](2021/homebrew.md) | 2021 | Dev Tooling | [1](https://brew.sh/2021/04/21/security-incident-disclosure/), [2](https://hackerone.com/reports/1167608) |
+| [Codecov](2021/codecov.md) | 2021 | Source Code | [1](https://about.codecov.io/security-update/) |
 | [Repojacking exposed private repositories through supply-chain compromise](2021/repojacking.md) | 2021 | Negligence | [1](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610) |
-| [VSCode GitHub](2021/vscode.md) | 2021 | Dev Tooling | [1](https://www.bleepingcomputer.com/news/security/heres-how-a-researcher-broke-into-microsoft-vs-codes-github/) |  |
-| [SUNBURST/SUNSPOT/Solarigate](2020/solarwinds.md) | 2020 | Publishing Infrastructure | [1](https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html), [2](https://msrc-blog.microsoft.com/2020/12/13/customer-guidance-on-recent-nation-state-cyber-attacks/), [3](https://www.crowdstrike.com/blog/sunspot-malware-technical-analysis/) |  |
+| [VSCode GitHub](2021/vscode.md) | 2021 | Dev Tooling | [1](https://www.bleepingcomputer.com/news/security/heres-how-a-researcher-broke-into-microsoft-vs-codes-github/) |
+| [SUNBURST/SUNSPOT/Solarigate](2020/solarwinds.md) | 2020 | Publishing Infrastructure | [1](https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html), [2](https://msrc-blog.microsoft.com/2020/12/13/customer-guidance-on-recent-nation-state-cyber-attacks/), [3](https://www.crowdstrike.com/blog/sunspot-malware-technical-analysis/) |
 | [The Great Suspender](2020/thegreatsuspender.md) | 2020 | Malicious Maintainer | [1](https://github.com/greatsuspender/thegreatsuspender/issues/1263),[2](https://lifehacker.com/ditch-the-great-suspender-before-it-becomes-a-security-1845989664) |
 | [Abusing misconfigured SonarQube applications](2020/sonarqube.md) | 2020 | Dev Tooling | [1](https://www.zdnet.com/article/fbi-hackers-stole-source-code-from-us-government-agencies-and-private-companies/), [2](https://www.ic3.gov/Media/News/2020/201103-3.pdf) |
 | [Octopus Scanner](2020/octopus_scanner.md) | 2020 | Dev Tooling | [1](https://securitylab.github.com/research/octopus-scanner-malware-open-source-supply-chain),[2](https://threatpost.com/octopus-scanner-tentacles-github-repositories/156204/) |
@@ -72,7 +72,7 @@ of compromise needs added, please include that as well.
 | [Operation Red](2018/operation-red.md) | 2018 | Publishing Infrastructure | [1](https://blog.trendmicro.com/trendlabs-security-intelligence/supply-chain-attack-operation-red-signature-targets-south-korean-organizations/) |
 | [RCE in go get -u](2018/gogetu.md) | 2018 | Dev Tooling | [1](https://github.com/golang/go/issues/29230), [2](https://staaldraad.github.io/post/2019-03-28-go-get-vuln/) |
 | [acroread compromised in AUR](2018/aur.md) | 2018 | Malicious Maintainer | [1](https://lists.archlinux.org/pipermail/aur-general/2018-July/034152.html), [2](https://www.bleepingcomputer.com/news/security/malware-found-in-arch-linux-aur-package-repository/) |
-| [Gentoo Incident](2018/gentoo.md) | 2018    | Source Code | [1](https://wiki.gentoo.org/wiki/Project:Infrastructure/Incident_Reports/2018-06-28_Github)
+| [Gentoo Incident](2018/gentoo.md) | 2018    | Source Code | [1](https://wiki.gentoo.org/wiki/Project:Infrastructure/Incident_Reports/2018-06-28_Github) |
 | [Unnamed Maker](2018/unnamed-maker.md) | 2018 | Publishing Infrastructure | [1](https://www.bleepingcomputer.com/news/security/microsoft-discovers-supply-chain-attack-at-unnamed-maker-of-pdf-software/) |
 | [Colourama](2018/colourama.md) | 2018 | Negligence | [1](https://medium.com/@bertusk/cryptocurrency-clipboard-hijacker-discovered-in-pypi-repository-b66b8a534a8), [2](https://arstechnica.com/information-technology/2018/10/two-new-supply-chain-attacks-come-to-light-in-less-than-a-week/) |
 | [Foxif/CCleaner](2017/ccleaner.md) | 2017 | Publishing Infrastructure | [1](https://blog.talosintelligence.com/2017/09/avast-distributes-malware.html) |
@@ -81,17 +81,17 @@ of compromise needs added, please include that as well.
 | [HackTask](2017/hacktask.md) | 2017 | Negligence | [1](https://securityintelligence.com/news/typosquatting-attack-puts-developers-at-risk-from-infected-javascript-packages/) |
 | [NotPetya](2017/notpetya.md) | 2017 | Attack Chaining | [1](https://www.welivesecurity.com/2017/07/04/analysis-of-telebots-cunning-backdoor/) |
 | [Bitcoin Gold](2017/bitcoingold.md) | 2017 | Source Code | [1](https://bitcoingold.org/critical-warning-nov-26/) |
-| [ExpensiveWall](2017/expensivewall.md) | 2017 | Dev Tooling | [1](https://blog.checkpoint.com/2017/09/14/expensivewall-dangerous-packed-malware-google-play-will-hit-wallet/), [2](https://research.checkpoint.com/expensivewall-dangerous-packed-malware-google-play-will-hit-wallet/)
+| [ExpensiveWall](2017/expensivewall.md) | 2017 | Dev Tooling | [1](https://blog.checkpoint.com/2017/09/14/expensivewall-dangerous-packed-malware-google-play-will-hit-wallet/), [2](https://research.checkpoint.com/expensivewall-dangerous-packed-malware-google-play-will-hit-wallet/) |
 | [OSX Elmedia player](2017/elmedia.md) | 2017 | Publishing infrastructure | [1](https://www.hackread.com/hackers-infect-mac-users-proton-malware-using-elmedia-player/) |
 | [GitHub password recovery issues](2016/gh-unicode.md) | 2016 | Dev Tool <br> Source Code </br> | [1](https://bounty.github.com/researchers/jagracey.html), [2](https://dev.to/jagracey/hacking-github-s-auth-with-unicode-s-turkish-dotless-i-460n) |
 | [keydnap](2016/keydnap.md) | 2016 | Publishing infrastructure | [1](https://blog.malwarebytes.com/threat-analysis/2016/09/transmission-hijacked-again-to-spread-malware), [2](https://www.welivesecurity.com/2016/08/30/osxkeydnap-spreads-via-signed-transmission-application/) |
 | [Fosshub Breach](2016/fosshub.md) | 2016 | Publishing infrastructure | [1](https://www.ghacks.net/2016/08/03/attention-fosshub-downloads-compromised/), [2](https://www.theregister.co.uk/2016/08/04/classicshell_audicity_infection/) |
 | [Linux Mint](2016/mint.md) | 2016 | Publishing infrastructure | [1](https://www.zdnet.com/article/linux-mint-website-hacked-malicious-backdoor-version/) |
-| [Juniper Incident](2015/juniper.md) | 2015    | Source Code | [1](https://eprint.iacr.org/2016/376.pdf)
+| [Juniper Incident](2015/juniper.md) | 2015    | Source Code | [1](https://eprint.iacr.org/2016/376.pdf) |
 | [XCodeGhost](2015/xcodeghost.md) | 2015 | Fake toolchain | [1](https://www.theregister.co.uk/2015/09/21/xcodeghost_apple_ios_store_malware_zapped/) |
 | [Ceph and Inktank](2015/ceph-and-inktank.md) | 2015 | Source Code <br> Publishing infrastructure </br> | [1](https://www.zdnet.com/article/red-hats-ceph-and-inktank-code-repositories-were-cracked/) |
-| [Code Spaces](2014/code-spaces.md) | 2014    | Source Code | [1](https://threatpost.com/hacker-puts-hosting-service-code-spaces-out-of-business/106761/)
-| [Monju Incident](2014/monju.md) | 2014    | Publishing infrastructure| [1](https://www.contextis.com/en/blog/context-threat-intelligence-the-monju-incident)
+| [Code Spaces](2014/code-spaces.md) | 2014    | Source Code | [1](https://threatpost.com/hacker-puts-hosting-service-code-spaces-out-of-business/106761/) |
+| [Monju Incident](2014/monju.md) | 2014    | Publishing infrastructure| [1](https://www.contextis.com/en/blog/context-threat-intelligence-the-monju-incident) |
 | [APT lack of validation for source packages](2013/apt.md) | 2013 | Negligence | [1](https://lwn.net/Articles/602461/) |
 | [GitHub rails/rails Vulnerability](2012/ruby-on-rails-github.md) | 2012 | Source Code <br> Dev Tooling | [1](https://homakov.blogspot.com/2012/03/how-to.html), [2](https://github.blog/2012-03-05-responsible-disclosure-policy/) |
 | [kernel.org compromise](2011/kernelorg.md) | 2011 | Publishing infrastructure | [1](https://lwn.net/Articles/461237/), [2](https://lwn.net/Articles/461552/) |

--- a/supply-chain-security/compromises/README.md
+++ b/supply-chain-security/compromises/README.md
@@ -101,6 +101,7 @@ of compromise needs added, please include that as well.
 | [ProFTPD](2010/proftpd.md) | 2010 | Publishing Infrastructure | [1](https://www.zdnet.com/article/open-source-proftpd-hacked-backdoor-planted-in-source-code/) |
 | [WordPress backdoor](2007/wordpress.md) | 2007 | Source Code <br> Publishing Infrastructure </br> | [1](https://lwn.net/Articles/224997/) |
 | [SquirrelMail backdoor](2007/squirrelmail.md) | 2007 | Source Code <br> Publishing Infrastructure | [1](https://lwn.net/Articles/262688/) |
+| [Linux Kernel CVS Repository Hack](2003/kernel-repository.md) | 2003 | Source Code <br> Dev Tooling | [1](https://lwn.net/Articles/57135/) |
 | [gentoo rsync compromise](2003/gentoo-rsync.md) | 2003 | Publishing Infrastructure | [1](https://archives.gentoo.org/gentoo-announce/message/7b0581416ddd91522c14513cb789f17a) |
 | [Debian infra compromise](2003/debian.md) | 2003 | Publishing infrastructure | [1](https://www.debian.org/News/2003/20031202) |
 | [Unix Support Group login backdoor](1984/login-bell.md) | <1984 | Dev Tooling | [1](https://niconiconi.neocities.org/posts/ken-thompson-really-did-launch-his-trusting-trust-trojan-attack-in-real-life/) |

--- a/supply-chain-security/compromises/README.md
+++ b/supply-chain-security/compromises/README.md
@@ -31,8 +31,8 @@ of compromise needs added, please include that as well.
 | Name              | Year               | Type of compromise    | Link        |
 | ----------------- | ------------------ | ------------------    | ----------- |
 | [Fake Dependabot commits](2023/fake-dependabot.md) | 2023 | Source Code | [1](https://checkmarx.com/blog/surprise-when-dependabot-contributes-malicious-code/) |
-| [Okta Source Code Theft](2022/okta-github-repo-leak.md) | 2022 | Source Code <br> Dev Tooling | [1](https://www.bleepingcomputer.com/news/security/oktas-source-code-stolen-after-github-repositories-hacked/)
-| [Auth0 Source Code Theft](2022/auth0-source-code-leak.md) | 2022 | Source Code <br> Dev Tooling | [1](https://auth0.com/blog/auth0-code-repository-archives-from-2020-and-earlier/) [2](https://www.bleepingcomputer.com/news/security/auth0-warns-that-some-source-code-repos-may-have-been-stolen/)
+| [Okta Source Code Theft](2022/okta-github-repo-leak.md) | 2022 | Source Code <br> Dev Tooling | [1](https://www.bleepingcomputer.com/news/security/oktas-source-code-stolen-after-github-repositories-hacked/) |
+| [Auth0 Source Code Theft](2022/auth0-source-code-leak.md) | 2022 | Source Code <br> Dev Tooling | [1](https://auth0.com/blog/auth0-code-repository-archives-from-2020-and-earlier/) [2](https://www.bleepingcomputer.com/news/security/auth0-warns-that-some-source-code-repos-may-have-been-stolen/) |
 | [RubyGems Package Overwrite Flaw](2022/rubygems-override.md) | 2022 | Publishing Infrastructure | [1](https://www.bleepingcomputer.com/news/security/check-your-gems-rubygems-fixes-unauthorized-package-takeover-bug/)
 | [Legitimate software update mechanism abused to deliver wiper malware](2022/fantasy.md) | 2022 | Publishing Infrastructure | [1](https://www.welivesecurity.com/2022/12/07/fantasy-new-agrius-wiper-supply-chain-attack/)|
 | [Docker Hub malicious containers](2022/docker-hub-malicious-containers.md) | 2022 | Publishing Infrastructure | [1](https://www.bleepingcomputer.com/news/security/docker-hub-repositories-hide-over-1-650-malicious-containers/)

--- a/supply-chain-security/compromises/README.md
+++ b/supply-chain-security/compromises/README.md
@@ -93,6 +93,7 @@ of compromise needs added, please include that as well.
 | [Code Spaces](2014/code-spaces.md) | 2014    | Source Code | [1](https://threatpost.com/hacker-puts-hosting-service-code-spaces-out-of-business/106761/)
 | [Monju Incident](2014/monju.md) | 2014    | Publishing infrastructure| [1](https://www.contextis.com/en/blog/context-threat-intelligence-the-monju-incident)
 | [APT lack of validation for source packages](2013/apt.md) | 2013 | Negligence | [1](https://lwn.net/Articles/602461/) |
+| [GitHub rails/rails Vulnerability](2012/ruby-on-rails-github.md) | 2012 | Source Code <br> Dev Tooling | [1](https://homakov.blogspot.com/2012/03/how-to.html), [2](https://github.blog/2012-03-05-responsible-disclosure-policy/) |
 | [kernel.org compromise](2011/kernelorg.md) | 2011 | Publishing infrastructure | [1](https://lwn.net/Articles/461237/), [2](https://lwn.net/Articles/461552/) |
 | [FSF Website Hack](2010/fsf-website.md) | 2010 | Source Code | [1](https://www.computerworld.com/article/2752415/free-software-foundation-s-software-repository-hacked.html) |
 | [apache.org incident](2010/apache.md) | 2010 | Attack Chaining | [1](https://blogs.apache.org/infra/entry/apache_org_04_09_2010) |


### PR DESCRIPTION
This PR adds various incidents to the supply chain compromises catalog:
- Okta GitHub repo hack
- Auth0 source code theft
- Linux kernel CVS repo hack
- Ruby on Rails / GitHub vulnerability exploited by security researcher
- FSF website hack
- Fake dependabot commits

In addition, it fixes tags on the PHP Git server incident.