### PR TITLE
fix(links): shift file transfer to content directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 ![Cloud Native Security Logo](/design/logo/cloud-native-security-horizontal-darkmodesafe.svg)
 
+<!-- markdown-link-check-disable -->
 ## Quick links
 
 - [Meeting Information](#meeting-times)
 - [Slack Information](#communications)
 - [New Members](#new-members)
 - [Members](#members)
+<!-- markdown-link-check-enable -->
 
 ## Objective
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ found in the [publications](PUBLICATIONS.md) document.
 ## Governance
 
 [Security TAG charter](governance/charter.md) outlines the scope of our group
-activities, as part of our [governance process](governance) which details how we
+activities, as part of our [governance process](governance/README.md) which details how we
 work.
 
 ## Communications
@@ -105,7 +105,7 @@ our [New Members Page](NEW-MEMBERS.md)
 
 There are several groups that are affiliated to or do work and cover topics
 relevant to the work of Security TAG. These can be
-seen [here](governance/related-groups/)
+seen [here](governance/related-groups/README.md)
 
 ## History
 
@@ -180,7 +180,7 @@ Co-chair representatives: @sublimino @PushkarJ
 Software Supply Chain attacks have come to the wider community's attention
 following recent high-profile attack, but have been an ongoing threat for a long
 time. With the ever growing importance of free and open source software,
-software [supply chain security](./supply-chain-security) is crucial,
+software [supply chain security](./supply-chain-security/README.md) is crucial,
 particularly in cloud native environments where everything is software-defined.
 
 Weekly meetings at 8:00 AM PT (50 min) (see your

--- a/governance/README.md
+++ b/governance/README.md
@@ -7,7 +7,7 @@ a [CNCF Technical Advisory Group](https://github.com/cncf/toc/tree/main/tags).
 * [Roles](roles.md) - the work of the group is facilitated by Chairs, Technical
   Leads, and active group members
 * [Process](process.md) - how projects are proposed and work is tracked
-* [Related Groups](./related-groups/README.md) - list of CNCF, Kubernetes and
+* [Related Groups](related-groups/README.md) - list of CNCF, Kubernetes and
   other Industry wide groups that do related work
 
 General meetings are posted on the CNCF calendar and serve as a forum for

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,6 +1,6 @@
 deps:
-	rsync -av ../* root/ --exclude=website --exclude=root/design/colors
-	rsync -av 'root/design/' 'static/design/' --exclude='#*'
+	rsync -av ../ content/ --include='assessments' --include='governance' --include='governance/related-groups' --include='supply-chain-security' --include='*.md' --exclude='*'
+	rsync -av '../design/' 'static/design/' --exclude='#*'
 	git submodule update --init --recursive
 
 serve: deps

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -3,4 +3,4 @@
 
 # Security Technical Advisory Group
 
-{{< include-markdown "root/README.md" "false" >}}
+{{< include-markdown "content/README.md" "false" >}}


### PR DESCRIPTION
Closes #1244 

Much more to do on the website - but this resolves a majority of the broken links identified in the linked issue. 

I don't see support for utilization of a `root/` content directory in conjunction with the standard `content/` directory for the website. 

## Solution
Copy required files to the `website/content` directory in order to support resolving links from the homepage to other markdown files within the repository. 

## Follow on work
Would be good to standardize the repository with what we intended to expose via the website. Rsync command was re-worked to essentially deny everything by default unless allowed. 