### PR TITLE
Added website relaunch blog

### DIFF
--- a/ci/spelling-config.json
+++ b/ci/spelling-config.json
@@ -22,6 +22,7 @@
         "cloudcustodian",
         "CMMC",
         "CNCF",
+        "CNSC",
         "CNSMAP",
         "CNSWP",
         "CNSWP's",

--- a/website/content/blog/website-relaunch-2024.md
+++ b/website/content/blog/website-relaunch-2024.md
@@ -15,7 +15,7 @@ Our community has done a great deal for the growth of open source security, alon
 
 Members and sponsors of CNCF can be proud that their contributions have gone toward more than 30 comprehensive security audits of projects in our ecosystem. TAG Security contributors, including project maintainers, have provided over 35 security [assessments](/community/assessments) that can be viewed publicly.
 
-In addition to those assessments and the industry-shaping publications released by TAG Security, we have also seen CNCF projects dramatically improve their security hygiene after engaging with one of our initiatives. Based on historical metrics that can easily be viewed on [CLOMonitor](https://clomonitor.io), projects that participate in the Cloud Native Security Slam perform _significantly_ higher month-over-month on metrics that are statistically correlated to reductions in the rate of CVEs.
+In addition to those assessments and the industry-shaping publications released by TAG Security, we have also seen CNCF projects dramatically improve their security hygiene after engaging with our initiatives. Based on historical metrics that can easily be viewed on [CLOMonitor](https://clomonitor.io), projects that participate in the Cloud Native Security Slam perform _significantly_ higher month-over-month on metrics that are statistically correlated to reductions in the rate of CVEs.
 
 Still, the open source community— including CNCF— have gaps to address. You should have heard of the Polyfill compromise by now... but what you may not know is that concerns were raised across the community months before the attack began. This, `xz`, and too many other supply chain attacks have been possible in part because the community of end-users has failed to _effectively_ support project maintainers.
 
@@ -23,12 +23,12 @@ To be effective, we need to constantly try new approaches where we have previous
 
 Here in TAG Security we aim to lead by example. We hope to create an open and encouraging space for folks from across the open source community to not only improve their own cloud native security, but also support project maintainers through the sharing of knowledge and targeted improvement initiatives.
 
-In an effort to increase our effectiveness, we have recently raised our standard of communication and publication. The website redesign is part of that effort.
+In an effort to increase our effectiveness, we have recently begun a concerted effort to increase the quality of our communications and publications. The website redesign is part of that effort.
 
 If you follow along with our work in the coming weeks, you will also see:
 
 1. A reorganization to the GitHub repo, with the directory structure being used to better organize content according to the [working group](/community) that manages it.
-2. A clearer criteria for [publishing](/publications/) through TAG Security, with an emphasis on facilitating a clear review process that holds all content to a high standard.
+2. A clearer criteria for publishing TAG Security [publications](/publications/), with an emphasis on facilitating a clear review process that holds all content to a high standard.
 3. A new process for regularly featuring opinion pieces and announcements from the community through this blog portal.
 
 We're excited to continue in our role as CNCF's Technical Advisory Group for Security, and we hope you're excited to [join us](/#meeting-information)!

--- a/website/content/blog/website-relaunch-2024.md
+++ b/website/content/blog/website-relaunch-2024.md
@@ -9,7 +9,7 @@ A lot is happening in the world of TAG Security recently! Most notably, this web
 
 At the time of this publication, a large portion of the cloud native security community is gathered in Seattle for CloudNativeSecurityCon North America, where Chris Aniszczyk is on stage calling the community to a higher standard— to "Grow up!"
 
-> It is our responsibility, as a community, to ensure there are safe and secure practices for the cloud native ecosystem, so we can continue to run the majority of the world’s workloads. - Chris Aniszyk
+> It is our responsibility, as a community, to ensure there are safe and secure practices for the cloud native ecosystem, so we can continue to run the majority of the world’s workloads. - Chris Aniszczyk
 
 Our community has done a great deal for the growth of open source security, along with others across the Linux Foundation and beyond, and it's worth taking a moment to celebrate the wins.
 

--- a/website/content/blog/website-relaunch-2024.md
+++ b/website/content/blog/website-relaunch-2024.md
@@ -1,6 +1,6 @@
 ---
 title:  "Website Re-Launch at CNSC '24"
-date:   2024-06-25 09:00:00 -0700
+date:   2024-06-26 09:00:00 -0700
 author: Eddie Knight 
 ---
 <!-- cSpell:ignore Benedictis Aniszczyk  -->

--- a/website/content/blog/website-relaunch-2024.md
+++ b/website/content/blog/website-relaunch-2024.md
@@ -1,0 +1,33 @@
+---
+title:  "Website Re-Launch at CNSC '24"
+date:   2024-06-26 09:00:00 -0700
+author: Eddie Knight 
+---
+
+A lot is happening in the world of TAG Security recently! Most notably, this website is re-launching with a whole new set of content— thanks to contributions from the TAG leads and the special attention paid by TAG members **Brandt Keller** and **Marco De Benedictis**.
+
+At the time of this publication, a large portion of the cloud native security community is gathered in Seattle for CloudNativeSecurityCon North America, where Chris Aniszyk is on stage calling the community to a higher standard— to "Grow up!"
+
+> It is our responsibility, as a community, to ensure there are safe and secure practices for the cloud native ecosystem, so we can continue to run the majority of the world’s workloads. - Chris Aniszyk
+
+Our community has done a great deal for the growth of open source security, along with others across the Linux Foundation and beyond, and it's worth taking a moment to celebrate the wins.
+
+Members and sponsors of CNCF can be proud that their contributions have gone toward more than 30 comprehensive security audits of projects in our ecosystem. TAG Security contributors, including project maintainers, have provided over 35 security [assessments](/community/assessments) that can be viewed publicly.
+
+In addition to those assessments and the industry-shaping publications released by TAG Security, we have also seen CNCF projects dramatically improve their security hygiene after engaging with one of our initiatives. Based on historical metrics that can easily be viewed on [CLOMonitor](https://clomonitor.io), projects that participate in the Cloud Native Security Slam perform _significantly_ higher month-over-month on metrics that are statistically correlated to reductions in the rate of CVEs.
+
+Still, the open source community— including CNCF— have gaps to address. You should have heard of the Polyfill compromise by now... but what you may not know is that concerns were raised across the community months before the attack began. This, `xz`, and too many other supply chain attacks have been possible in part because the community of end-users has failed to _effectively_ support project maintainers.
+
+To be effective, we need to constantly try new approaches where we have previously failed.
+
+Here in TAG Security we aim to lead by example. We hope to create an open and encouraging space for folks from across the open source community to not only improve their own cloud native security, but also support project maintainers through the sharing of knowledge and targeted improvement initiatives.
+
+In an effort to increase our effectiveness, we have recently raised our standard of communication and publication. The website redesign is part of that effort.
+
+If you follow along with our work in the coming weeks, you will also see:
+
+1. A reorganization to the GitHub repo, with the directory structure being used to better organize content according to the [working group](/community) that manages it.
+2. A clearer criteria for [publishing](/publications/) through TAG Security, with an emphasis on facilitating a clear review process that holds all content to a high standard.
+3. A new process for regularly featuring opinion pieces and announcements from the community through this blog portal.
+
+We're excited to continue in our role as CNCF's Technical Advisory Group for Security, and we hope you're excited to [join us](/#meeting-information)!

--- a/website/content/blog/website-relaunch-2024.md
+++ b/website/content/blog/website-relaunch-2024.md
@@ -1,12 +1,13 @@
 ---
 title:  "Website Re-Launch at CNSC '24"
-date:   2024-06-26 09:00:00 -0700
+date:   2024-06-25 09:00:00 -0700
 author: Eddie Knight 
 ---
+<!-- cSpell:ignore Benedictis Aniszczyk  -->
 
 A lot is happening in the world of TAG Security recently! Most notably, this website is re-launching with a whole new set of content— thanks to contributions from the TAG leads and the special attention paid by TAG members **Brandt Keller** and **Marco De Benedictis**.
 
-At the time of this publication, a large portion of the cloud native security community is gathered in Seattle for CloudNativeSecurityCon North America, where Chris Aniszyk is on stage calling the community to a higher standard— to "Grow up!"
+At the time of this publication, a large portion of the cloud native security community is gathered in Seattle for CloudNativeSecurityCon North America, where Chris Aniszczyk is on stage calling the community to a higher standard— to "Grow up!"
 
 > It is our responsibility, as a community, to ensure there are safe and secure practices for the cloud native ecosystem, so we can continue to run the majority of the world’s workloads. - Chris Aniszyk
 


### PR DESCRIPTION
It would be nice to have a recent post on the blog when we announce the website revamp in the CNSC keynotes.

This won't show on the preview or website until after the release time passes.

![image](https://github.com/cncf/tag-security/assets/21176439/c2f04a57-ba16-45d7-afd8-53963f943c17)
