### PR TITLE
Upgrade website netlify hugo version

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -6,7 +6,7 @@ ignore = "exit 1"
 
 [build.environment]
 NODE_VERSION = "18.16.1"
-HUGO_VERSION = "0.115.2"
+HUGO_VERSION = "0.128.0"
 
 [context.production.environment]
 HUGO_ENV = "production"

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4,10 +4,9 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "website",
       "dependencies": {
         "autoprefixer": "^10.4.0",
-        "hugo-extended": "^0.115.2",
+        "hugo-extended": "^0.127.0",
         "postcss": "^8.4.31",
         "postcss-cli": "^9.1.0"
       }
@@ -1000,9 +999,9 @@
       }
     },
     "node_modules/hugo-extended": {
-      "version": "0.115.4",
-      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.115.4.tgz",
-      "integrity": "sha512-sZQ+melq3ZDUeKhOoz/ElpS/5LA77F2z8RllGPsi/OPt3otexMSucunTvZzjLuoebaHW/g11DgMmlx1CPgYvLA==",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.127.0.tgz",
+      "integrity": "sha512-TDjizLf8cUpkRPkHXeDq3rZJKSAUdguV7KPddOZrclNcnL1QQh/9BgKddCZP0+4/nolPOb6GI+2LhIehfjrUHw==",
       "hasInstallScript": true,
       "dependencies": {
         "careful-downloader": "^3.0.0",
@@ -1014,7 +1013,7 @@
         "hugo-extended": "lib/cli.js"
       },
       "engines": {
-        "node": ">=14.14"
+        "node": ">=16.14"
       }
     },
     "node_modules/ieee754": {

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "autoprefixer": "^10.4.0",
-    "hugo-extended": "^0.115.2",
+    "hugo-extended": "^0.127.0",
     "postcss": "^8.4.31",
     "postcss-cli": "^9.1.0"
   }


### PR DESCRIPTION
This PR attempts to bump the Hugo version used by netlify when building the website from 0.115.2 (released in [July 2023](https://github.com/gohugoio/hugo/releases/tag/v0.115.2)) to 0.128.0, the [latest stable release at this time](https://github.com/gohugoio/hugo/releases/tag/v0.128.0). 

The PR also bumps the hugo-extended npm package version to latest stable: https://www.npmjs.com/package/hugo-extended/v/0.127.0