### PR TITLE
Fix website publications table link column

### DIFF
--- a/website/themes/docsy/assets/scss/_table.scss
+++ b/website/themes/docsy/assets/scss/_table.scss
@@ -1,0 +1,5 @@
+#tag-security-publications ~ table {
+	td:nth-child(4) {
+		white-space: nowrap;
+	}
+}

--- a/website/themes/docsy/assets/scss/main.scss
+++ b/website/themes/docsy/assets/scss/main.scss
@@ -26,6 +26,7 @@
 @import "blocks/blocks";
 @import "section-index";
 @import "pageinfo";
+@import "table";
 
 @if $td-enable-google-fonts {
     @import url($web-font-path);


### PR DESCRIPTION
This SCSS fix addresses the following action item in https://github.com/cncf/tag-security/issues/1257

> The publications table is too wide— in the final column "Link" four letters is getting broken up into two lines.