### PR TITLE
Specify max size for TAG-Security logo on website homepage

### DIFF
--- a/website/themes/docsy/assets/scss/_logo.scss
+++ b/website/themes/docsy/assets/scss/_logo.scss
@@ -1,0 +1,3 @@
+img[alt="Cloud Native Security Logo"] {
+  max-width: 500px;
+}

--- a/website/themes/docsy/assets/scss/main.scss
+++ b/website/themes/docsy/assets/scss/main.scss
@@ -27,6 +27,7 @@
 @import "section-index";
 @import "pageinfo";
 @import "table";
+@import "logo";
 
 @if $td-enable-google-fonts {
     @import url($web-font-path);


### PR DESCRIPTION
The default styling for the TAG-Security logo on the website homepage does not constrain its size so it may be very large depending on the screen size.

![image](https://github.com/user-attachments/assets/8f0899ed-a683-4bd9-a940-1e71b8e29e88)

This PR addresses this style issue by enforcing a max size of 500px regardless of the size of the screen by using a specific SCSS selector for the logo image.