### PR TITLE
Update Lead for AG Working Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Each group, led by a responsible leader, reaches consensus on issues and manages
 | Project | Leads |
 |---------------------------------|---------------------------------------------|
 | [Research](/community/research/README.md) | Andrés Vega |
-| [Automated Governance](/community/automated-governance/README.md) | Andrés Vega, Brandt Keller |
+| [Automated Governance](/community/automated-governance/README.md) | Matthew Flannery, Brandt Keller |
 | [Catalog of Supply Chain Compromises](/community/catalog/README.md) | Santiago Arias Torres |
 | [Compliance](/community/compliance/README.md) | Anca Sailer, Robert Ficcaglia |
 | [Controls](/community/controls/README.md) | Jon Zeolla |


### PR DESCRIPTION
This PR updates the leadership for the Automated Governance Working Group. Due to other commitments, I will be stepping down as the lead for this group. @matthewflannery who has been a co-lead from the start, has graciously stepped up to take on the lead role along @brandtkeller. 