### PR TITLE
fix(ci): update Makefile to docker compose v2

### DIFF
--- a/.github/workflows/sig-sec-check.yml
+++ b/.github/workflows/sig-sec-check.yml
@@ -11,27 +11,27 @@ jobs:
   Setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Setup
         run: make setup
   Lint:
     runs-on: ubuntu-latest
     needs: Setup
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Lint
         run: make lint
   Spelling:
     runs-on: ubuntu-latest
     needs: Setup
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Spelling
         run: make spelling
   Links:
     runs-on: ubuntu-latest
     needs: Setup
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Links
         run: make links

--- a/Makefile
+++ b/Makefile
@@ -4,24 +4,24 @@ all: setup lint spelling links
 .PHONY: setup
 setup:
 	@echo "Running $@...\n\n"
-	@docker-compose run $@ ci/$@.sh
-	@docker-compose down
+	@docker compose run $@ ci/$@.sh
+	@docker compose down
 
 .PHONY: lint
 lint:
 	@echo "Running $@...\n\n"
-	@docker-compose run $@ ci/$@.sh
-	@docker-compose down
+	@docker compose run $@ ci/$@.sh
+	@docker compose down
 
 .PHONY: spelling
 spelling:
 	@echo "Running $@...\n\n"
-	@docker-compose run $@ ci/$@.sh
-	@docker-compose down
+	@docker compose run $@ ci/$@.sh
+	@docker compose down
 
 .PHONY: links
 links:
 	@echo "Running $@...\n\n"
-	@docker-compose run $@ ci/$@.sh
-	@docker-compose down
+	@docker compose run $@ ci/$@.sh
+	@docker compose down
 

--- a/community/automated-governance/README.md
+++ b/community/automated-governance/README.md
@@ -24,5 +24,5 @@ The scope of this project includes:
 
 ## Contact
 
-- **Lead:** Andrés Vega, Brandt Keller
+- **Lead:** Matthew Flannery, Brandt Keller
 - **Slack Channel:** [Link](https://cloud-native.slack.com/archives/C06B26A12AF)

--- a/community/automated-governance/README.md
+++ b/community/automated-governance/README.md
@@ -24,5 +24,5 @@ The scope of this project includes:
 
 ## Contact
 
-- **Lead:** Matthew Flannery, Brandt Keller
+- **Lead:** Andrés Vega, Brandt Keller
 - **Slack Channel:** [Link](https://cloud-native.slack.com/archives/C06B26A12AF)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: '2'
 services:
   setup:
     image: node:18


### PR DESCRIPTION
# Description

Noticed failures with CI processes in Pull Requests. Noticed that our use of `ubuntu-latest` may have resulted in these issues after the [removal](https://github.com/actions/runner-images/commit/2a4bc14da46f1f8e358aa902a69edb9bef135472) of docker compose v1. 

## Updates
- Update `Makefile` to use docker compose v2 syntax
- Remove obsolete `version` in `docker-compose.yml`
- Update the `TAG-Security-Linter` to use the latest version of `actions/checkout` pinned to the commit SHA to remove deprecation warnings with the use of older `node` actions. 