### PR TITLE
Remove personal references (Andres Vega and @anvega) from project files and documentation

### DIFF
--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -19,7 +19,6 @@ reviewers:
       - JustinCappos
       - achetal01
       - ashutosh-narkar
-      - anvega
       - PushkarJ
       - mnm678
       - mlieberman85

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Each group, led by a responsible leader, reaches consensus on issues and manages
 
 | Project | Leads |
 |---------------------------------|---------------------------------------------|
-| [Research](/community/research/README.md) | Andrés Vega |
 | [Automated Governance](/community/automated-governance/README.md) | Matthew Flannery, Brandt Keller |
 | [Catalog of Supply Chain Compromises](/community/catalog/README.md) | Santiago Arias Torres |
 | [Compliance](/community/working-groups/compliance/README.md) | Anca Sailer, Robert Ficcaglia |

--- a/community/resources/security-whitepaper/secure-defaults-cloud-native-8.md
+++ b/community/resources/security-whitepaper/secure-defaults-cloud-native-8.md
@@ -3,7 +3,7 @@
 <!-- cspell:disable -->
 **Author**: Pushkar Joglekar
 
-**Contributors** (alphabetical order): Andres Vega, Emily Fox, Faraz Angabini,
+**Contributors** (alphabetical order): Emily Fox, Faraz Angabini,
 Robert Clark, Robert Van Voorhees
 <!-- cspell:enable -->
 


### PR DESCRIPTION
Remove personal references (Andres Vega and @anvega) from README.md, and auto_request_review.yml to complete https://github.com/cncf/tag-security/issues/1349. 