### PR TITLE
Adds CNCF "hello" bar above topnav

### DIFF
--- a/website/layouts/partials/head.html
+++ b/website/layouts/partials/head.html
@@ -16,6 +16,7 @@
 {{- partial "twitter_cards.html" . -}}
 
 <script src="https://cmp.osano.com/16A0DbT9yDNIaQkvZ/c3494b1e-ff3a-436f-978d-842e9a0bed27/osano.js"></script>
+<script defer src="https://www.cncf.io/wp-content/themes/cncf-twenty-two/source/js/on-demand/hello-bar-embed.js"></script>
 
 {{ if hugo.IsProduction }}
   <!-- Google Tag Manager -->


### PR DESCRIPTION
As part of the LF push to advertise events more broadly, this deploys the "hello" bar seen at the top of the CNCF site. It will be deployed to all CNCF subsites as per [this issue](https://github.com/cncf/cncf.io/issues/598). It takes its settings from the main CNCF site and will appear only when the CNCF site has it active.

![Screenshot 2024-09-30 at 2 26 12 PM](https://github.com/user-attachments/assets/a62fbf68-e373-4e93-a53d-250049ec843d)

