### PR TITLE
Update README.md to remove Members heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,6 @@ If you are new to the group, we encourage you to check out our
 
 Explore groups affiliated with or relevant to Security TAG [here](governance/related-groups/README.md)
 
-## Members
-
-<!-- cSpell:disable -->
-
 ## Leadership
 
 Details about the TAG Chairs, Tech Leads, and TOC Liaisons can be found on the [CNCF Technical Advisory Groups (TAGs) information page](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md)


### PR DESCRIPTION
The Members heading in the past documented all contributing members. This has since been removed due to the sheer growth of contributors, and has been left in the README as an empty placeholder.

Thus, the "## Members" heading is redundant.