### PR TITLE
fix(lint): pin markdown-lint-link to known good version

### DIFF
--- a/ci/links.sh
+++ b/ci/links.sh
@@ -6,7 +6,7 @@ shopt -s globstar
 FAILURE=0
 
 git config --global --add safe.directory /usr/src/app
-npm install -g markdown-link-check
+npm install -g markdown-link-check@3.12.2
 git fetch origin main:main
 # To run this on the entire repo, replace the following command with `$(find ./ -type f | grep .md)`
 for file_name in $(git diff --name-only $HEAD main -- ./**/*.md); do


### PR DESCRIPTION
## Description

Fixes #1402 

Pins the use of `markdown-link-check` to `3.12.2` following a regression in the latest releases which breaks with the use of config files. 

Tested locally with desired results. 