### PR TITLE
Updating the term 'review' to 'assessment' to meet new directives.

### DIFF
--- a/.github/ISSUE_TEMPLATE/joint-review.md
+++ b/.github/ISSUE_TEMPLATE/joint-review.md
@@ -1,7 +1,7 @@
 ---
-name: Joint security review
+name: Joint security assessment
 about: To request a joint review or track progress on active review
-title: "[Security Review] Project Name"
+title: "[Security Assessment] Project Name"
 labels: "triage-required"
 assignees: ''
 

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -32,7 +32,7 @@ In keeping with this commitment, we offer the following guidelines:
      Charter][charter],
      the open source license, and to be used for the equal benefit of all
      members of the community.  Further information on use of work may be found
-     in [Security Reviews:
+     in [Security Assessments:
      Outcome][review-outcome]
 
 ## Incident handling and escalation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ contributions to our documentation.
 
 ### Reporting Security Issues
 
-This group engages in [security reviews] of projects to improve their security
+This group engages in [security assessments] of projects to improve their security
 posture. Discussions about potential issues must adhere to the project's
 security reporting process and remain close-held to ensure responsible
 disclosure.
@@ -197,7 +197,7 @@ Here are some additional sources for good content guidelines:
 [CODE-OF-CONDUCT.md]: CODE-OF-CONDUCT.md
 [help is needed]: https://github.com/cncf/tag-security/labels/help%20wanted
 [communication channels]: README.md#Communications
-[security reviews]: /community/assessments/README.md
+[security assessments]: /community/assessments/README.md
 [CNCF Slack guidelines]: https://github.com/cncf/foundation/blob/main/slack-guidelines.md
 [code of conduct]: ./CODE-OF-CONDUCT.md
 [CNCF Style Guide]: https://github.com/cncf/foundation/blob/main/style-guide.md

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Each group, led by a responsible leader, reaches consensus on issues and manages
 | [Commons](/community/working-groups/commons/README.md) | Eddie Knight | Marco De Benedictis |
 | [Compliance](/community/working-groups/compliance/README.md) | Anca Sailer, Robert Ficcaglia | Brandt Keller |
 | [Controls](/community/working-groups/controls/README.md) | Jon Zeolla | Brandt Keller |
-| [Security Reviews](/community/assessments/README.md) | Justin Cappos | Eddie Knight |
+| [Security Assessments](/community/assessments/README.md) | Justin Cappos | Eddie Knight |
 | [Software Supply Chain](/community/working-groups/supply-chain-security/README.md) | Michael Lieberman, John Kjell | Marina Moore |
 
 ## Additional information
@@ -100,6 +100,6 @@ Each group, led by a responsible leader, reaches consensus on issues and manages
 
 For [CNCF project proposal process](https://github.com/cncf/toc/blob/main/process)
 create a
-new [security review issue](https://github.com/cncf/tag-security/issues/new?assignees=&labels=assessment&template=security-assessment.md&title=%5BAssessment%5D+Project+Name)
+new [security assessment issue](https://github.com/cncf/tag-security/issues/new?assignees=&labels=assessment&template=security-assessment.md&title=%5BAssessment%5D+Project+Name)
 with a
 [self-assessment](/community/assessments/guide/self-assessment.md).

--- a/community/assessments/guide/README.md
+++ b/community/assessments/guide/README.md
@@ -116,7 +116,7 @@ and facilitate the process.
 
 In order to remediate unfair advantage or ethical issues all reviewers are
 required to provide a statement indicating all hard and soft conflicts they
-maintain prior starting the security review.
+maintain prior starting the security assessment.
 
 * **Lead security reviewer and additional security reviewers** comment any
      conflict of interest in the project's assessment ticket using the below format:

--- a/community/assessments/guide/joint-assessment.md
+++ b/community/assessments/guide/joint-assessment.md
@@ -99,14 +99,14 @@ or overwhelming the servers)
 The joint-assessment is initially created by the project team and then
 collaboratively developed with the [security reviewers](security-reviewer.md) as
 part of the project's TAG-Security Security Assessment (TSSA) Process.
-Information about the TAG-Security Review can be found in the [CNCF TAG-Security
+Information about the TAG-Security Assessment can be found in the [CNCF TAG-Security
 Review Process Guide](./README.md).
 
 This document does not intend to provide a security audit of [project] and is
 not intended to be used in lieu of a security audit.  This document provides
 users of [project] with a security focused understanding of [project] and when
 taken with the [self-assessment](self-assessment.md) provide the community with
-the TAG-Security Review of the project.  Both of these documents may be used and
+the TAG-Security Assessment of the project.  Both of these documents may be used and
 references as part of a security audit.
 
 ## Intended Use

--- a/community/assessments/guide/project-lead.md
+++ b/community/assessments/guide/project-lead.md
@@ -1,6 +1,6 @@
 # Project lead
 
-In the context of the project security review and self-assessment, the
+In the context of the project security assessment and self-assessment, the
 "project lead" should be someone on the security team for the project.  For new
 or smaller projects without an established security team, this could be a
 project maintainer or they may delegate to a regular contributor with an

--- a/community/assessments/guide/security-reviewer.md
+++ b/community/assessments/guide/security-reviewer.md
@@ -64,10 +64,10 @@ of the reviewer and with authorization.
 ### Required
 
 Unless approved by TAG-Security chairs, the lead reviewer will have previously
-performed a CNCF security review.  Exemptions to this are reviewed case by
+performed a CNCF security assessment.  Exemptions to this are reviewed case by
 case upon established need by the CNCF TAG-Security chairs in order to bootstrap
 the process as appropriate.  If a lead reviewer has not previously performed a
-security review, and the chairs concur with them fulfilling the role, it is
+security assessment, and the chairs concur with them fulfilling the role, it is
 encouraged that at least 1 additional reviewer have experience and be leveraged
 as the delegate or designee by the lead.
 
@@ -183,7 +183,7 @@ The Security Assessment Facilitator or a TAG-Security chair must review the
 Lead Security Reviewer conflict-of-interest assertion.
 
 If any hard conflicts, or multiple significant soft conflicts, are presented,
-then a TAG-Security chair must approve the security review team. Reasons for
+then a TAG-Security chair must approve the security assessment team. Reasons for
  accepting and rejecting conflicts should be documented.
 
 In most cases, the existence of a hard conflict will prevent a TAG member from

--- a/community/assessments/projects/buildpacks/self-assessment.md
+++ b/community/assessments/projects/buildpacks/self-assessment.md
@@ -427,7 +427,7 @@ Native Ecosystem:
     * Additional work on image reproducibility
 * **CNCF Requests**
 
-    We would welcome a third-party security review.
+    We would welcome a third-party security assessment.
 
 ## **Appendix**
 

--- a/community/assessments/projects/flatcar/self-assessment.md
+++ b/community/assessments/projects/flatcar/self-assessment.md
@@ -12,7 +12,7 @@ Authors: Danielle Tal and Thilo Fromm
 
 [the Appendix](#heading=h.7dxoyq24wwg8))
 
-This self-assessment thoroughly reflects on Flatcar Container Linux’ security mechanisms and processes, and lists and assesses security documentation. The document aims to provide a foundation for a [joint security review](/community/assessments/guide/joint-assessment.md) of the Flatcar project; target audience is [joint assessment reviewers](/community/assessments/guide/security-reviewer.md).
+This self-assessment thoroughly reflects on Flatcar Container Linux’ security mechanisms and processes, and lists and assesses security documentation. The document aims to provide a foundation for a [joint security assessment](/community/assessments/guide/joint-assessment.md) of the Flatcar project; target audience is [joint assessment reviewers](/community/assessments/guide/security-reviewer.md).
 
 
 # Metadata

--- a/community/assessments/projects/harbor/self-assessment.md
+++ b/community/assessments/projects/harbor/self-assessment.md
@@ -1027,7 +1027,7 @@ All new features must pass human review as well as automated testing. The projec
 
 
 *   Golint and Govet for managing compiler warnings, coding style, and correctness
-*   Gosec is used before each release as part of the internal security review
+*   Gosec is used before each release as part of the internal security assessment
 *   Black Duck Binary analysis is run every night for application security testing used to find security vulnerabilities that can make an application susceptible to attack
 
 

--- a/community/assessments/projects/openfga/joint-assessment.md
+++ b/community/assessments/projects/openfga/joint-assessment.md
@@ -158,14 +158,14 @@ With this information, OpenFGA can be queried in different ways:
 The joint-assessment is initially created by the project team and then
 collaboratively developed with the security reviewers as
 part of the project's TAG-Security Security Assessment (TSSA) Process.
-Information about the TAG-Security Review can be found in the [CNCF TAG-Security
-Review Process Guide](https://tag-security.cncf.io/assessments/guide/).
+Information about the TAG-Security Assessment can be found in the [CNCF TAG-Security
+Assessment Process Guide](https://tag-security.cncf.io/assessments/guide/).
 
 This document does not intend to provide a security audit of OpenFGA and is
 not intended to be used in lieu of a security audit.  This document provides
 users of the project with a security focused understanding of OpenFGA and, when
 taken with the [self-assessment](./self-assessment.md), provide the community with
-the TAG-Security Review of the project.  Both of these documents may be used and
+the TAG-Security Assessment of the project.  Both of these documents may be used and
 referenced as inputs to a separate security audit.
 
 OpenFGA is a project that provides a security service and as such, any defect
@@ -686,7 +686,7 @@ Artifacts included with each release:
 
 | Aspect | Details |
 |--------|---------|
-| Secure Development Practices | Optional secure development training is provided by Okta. | Security Review is done for every feature addition. |
+| Secure Development Practices | Optional secure development training is provided by Okta. | Security Assessment is done for every feature addition. |
 | Code Quality and Testing | CodeQL is used on every pull request. The team is confident in the test coverage. |
 | Binary Management | CLOMonitor check passes, and the team is aware of the dangers of allowing binaries in the project. |
 | OpenSSF Scorecard | Badge present. Score is 9.3, well above the average of 4. |

--- a/community/assessments/projects/openfga/self-assessment.md
+++ b/community/assessments/projects/openfga/self-assessment.md
@@ -524,7 +524,7 @@ The [list](https://github.com/openfga/community/blob/main/ADOPTERS.md) of projec
 
 The list of related projects is available as a [community resource](https://github.com/openfga/community/blob/main/related-projects.md)
 
-### Third Party Security Reviews
+### Third Party Security Assessments
 
 <!-- markdown-link-check-disable -->
 [Trail Of Bits](https://www.trailofbits.com/) published a [Comparative Language Security Assessment](https://github.com/trailofbits/publications/blob/master/reports/Policy_Language_Security_Comparison_and_TM.pdf) that evaluates Cedar, Rego and OpenFGA.

--- a/community/assessments/projects/spiffe-spire/README.md
+++ b/community/assessments/projects/spiffe-spire/README.md
@@ -50,5 +50,5 @@ with non-critical issues captured as issues and noted below.
 The following recommendations are where help from the CNCF would assist SPIFFE/SPIRE to
 increase its effectiveness in cloud native security.
 
-* Conduct a formal security review/audit for the project as it is critical to security of services that use it.
+* Conduct a formal security assessment/audit for the project as it is critical to security of services that use it.
 * Provide an avenue for education of SPIFFE/SPIRE and advanced SPIFFE/SPIRE topology use cases for end users.

--- a/governance/roles.md
+++ b/governance/roles.md
@@ -289,11 +289,11 @@ welcome and PRs can be approved by any single Chair.
 
 ### Security assessment facilitator
 
-[Security Reviews](/community/assessments) are part of the ongoing work of the group
+[Security Assessment](/community/assessments) are part of the ongoing work of the group
 and led by a security assessment facilitator (referred to in the rest of this
 sub-section as a facilitator). The facilitator is responsible for:
 
-* Ensuring that security reviews follow the assessment process.
+* Ensuring that security assessments follow the assessment process.
 * Helping to bootstrap security assessments and reviews.
 * Determining assessment schedule of reviews, considering TOC requirements.
 
@@ -304,7 +304,7 @@ TAG-Security](https://github.com/cncf/tag-security/issues?q=is%3Aopen+is%3Aissue
 will be addressed.  The facilitator is then responsible for reaching out to the
 project owners (via the GitHub issue said owners previously created in order to
 request an assessment), and coordinating the various requirements as outlined
-in the ["Joint Security Review" ticket
+in the ["Joint Security Assessment" ticket
 template](https://github.com/cncf/tag-security/issues/new/choose). Once the
 maintainers/owners of the project have been identified, the facilitator is
 responsible for reaching out to the TAG-Security community at large (i.e.

--- a/project-resources/moving-levels-review-template.md
+++ b/project-resources/moving-levels-review-template.md
@@ -10,7 +10,7 @@ What ecosystem adoption has the project seen?
 
 If the project has undergone a previous TAG or TOC review, how has the project addressed comments from those reviews?
 
-## Security Reviews
+## Security Assessments
 
 ### TAG Security Assessments
 

--- a/website/content/blog/historical-presentations-June-24.md
+++ b/website/content/blog/historical-presentations-June-24.md
@@ -23,7 +23,7 @@ Enjoy!
 - [CNCF TAG-Security Deep Dive](https://kccnceu19.sched.com/event/Oscd/deep-dive-cncf-security-tag-justin-cappos-new-york-university-zhipeng-huang-huawei)
 \- [slides](https://docs.google.com/presentation/d/18nzXspPuRDRKfGUSI1ogFHmUOP_XHS78nz-0uTG9Ogs/edit?usp=sharing)
 | [video](https://www.youtube.com/watch?v=EF3nl80kpm4)
-- [Inside CNCF Project Security Reviews](https://kccnceu19.sched.com/event/MPdf/inside-the-cncf-project-security-reviews-justin-cormack-docker)
+- [Inside CNCF Project Security Assessments](https://kccnceu19.sched.com/event/MPdf/inside-the-cncf-project-security-reviews-justin-cormack-docker)
 \- [video](https://www.youtube.com/watch?v=0BkKpsrUo5k)
 
 ## Misc security-related talks


### PR DESCRIPTION
As we changed the "Security Review" to "Security Assessment", the TAG Security website got outdated with the term.
This PR updates not only the website, but also the references made to the Security Assessment (previously Security Review) on the TAG Security repository.