### PR TITLE
chore: update joint review template with redirection to toc repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/joint-review.md
+++ b/.github/ISSUE_TEMPLATE/joint-review.md
@@ -6,31 +6,5 @@ labels: "triage-required"
 assignees: ''
 
 ---
-
-Project Name:
-
-Github URL:
-
-<!-- For project proposals looking to go through TAG review, please indicate the stage of the project (sandbox, incubation/graduation and link to the TOC issue, else indicate NA
-
-For example, https://github.com/cncf/toc/issues/368 (incubation)
--->
-CNCF project stage and issue (NA if not applicable):
-
-Security Provider: yes/no (e.g. Is the primary function of the project to support the security of an integrating system?)
-
-- [ ] Identify team
-  - [ ] Project security lead
-  - [ ] Lead security reviewer
-  - [ ] 1 or more additional reviewer(s)
-  - [ ] Every reviewer has read [security reviewer guidelines](/community/assessments/guide/joint-assessment.md) and stated declaration of conflict
-  - [ ] Sign off by facilitator on reviewer conflicts
-- [ ] Create slack channel (e.g. #sec-assess-projectname)
-- [ ] Project lead provides draft document - see [outline](/community/assessments/guide/joint-assessment.md)
-- [ ] "Naive question phase" Lead Security Reviewer asks clarifying questions
-- [ ] Assign issue to security reviewers
-- [ ] Initial review
-- [ ] Presentation & discussion
-- [ ] Share draft findings with project
-- [ ] Assessment summary and doc checked into /assessments/projects/project-name (require at least 1 co-chair approval)
-- [ ] CNCF TOC presentation (if requested by TOC)
+# THIS TEMPLATE HAS MOVED ⚠️
+- [ ] I will submit an issue in the `cncf/toc` repo using this [template](https://github.com/cncf/toc/blob/main/.github/ISSUE_TEMPLATE/joint-security-review.md)


### PR DESCRIPTION
Update the `joint-revew` template to reflect the new location