### PR TITLE
fix(docs): correct broken link to compromises catalog (#1357)

### DIFF
--- a/community/working-groups/supply-chain-security/supply-chain-security-paper/sscsp.md
+++ b/community/working-groups/supply-chain-security/supply-chain-security-paper/sscsp.md
@@ -1025,7 +1025,7 @@ It is critical to note, however, that organizations are entirely responsible for
      https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html
 
 [^6]:
-     https://github.com/cncf/tag-security/tree/main/supply-chain-security/compromises
+     https://github.com/cncf/tag-security/tree/main/community/catalog/compromises
 
 [^7]:
      See, for example: https://www.atlanticcouncil.org/in-depth-research-reports/report/breaking-trust-shades-of-crisis-across-an-insecure-software-supply-chain/


### PR DESCRIPTION
This PR fixes #1357 by updating the broken /supply-chain-security/compromises link.
The link now points to the correct location:
https://github.com/cncf/tag-security/tree/main/community/catalog/compromises